### PR TITLE
hotfix: URLにvやtが含まれていると曲を変更出来ないのを修正

### DIFF
--- a/src/app/hook/usePlayerControls.tsx
+++ b/src/app/hook/usePlayerControls.tsx
@@ -456,9 +456,9 @@ const usePlayerControls = (
     player.playVideo();
     setIsPlaying(true);
 
-    // URLに「v」と「t」がセットで存在する場合、再生開始後にパラメータを削除
+    // URLに「v」と「t」が存在する場合、再生開始後にパラメータを削除
     const url = new URL(window.location.href);
-    if (url.searchParams.has("v") && url.searchParams.has("t")) {
+    if (url.searchParams.has("v") || url.searchParams.has("t")) {
       url.searchParams.delete("v");
       url.searchParams.delete("t");
       window.history.replaceState(null, "", url.toString());


### PR DESCRIPTION
```
https://azki-song-db.vercel.app/?v=PfffHh-IOpE&q=tag%3A%E3%82%AB%E3%83%90%E3%83%BC%E6%9B%B2
```

v と t がセットのときに消してたが、startが0秒の動画（MVとか）でvが消えずに曲を変更できなくなる。

https://github.com/mitsugogo/azki-song-db/blob/3c8f6fb0204b27e8f11d890a666f25f8600f5d87/src/app/hook/usePlayerControls.tsx#L459-L466