### PR TITLE
2026/07/01 リリース分（v2.9.0）

### DIFF
--- a/e2e/discography.spec.ts
+++ b/e2e/discography.spec.ts
@@ -1,10 +1,9 @@
 import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { setupApiMocks } from "./mocks";
 import { getCachedSongs } from "./test-utils";
 
-const waitForDiscographyTabs = async (
-  page: Parameters<typeof test>[0]["page"],
-) => {
+const waitForDiscographyTabs = async (page: Page) => {
   await expect(page.getByRole("heading", { name: /Discography/i })).toBeVisible(
     {
       timeout: 10000,
@@ -52,6 +51,48 @@ test.describe("Discography page", () => {
     // Look for images (album covers)
     const images = page.locator("img");
     await expect(images.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test("album page groups MV and art track with variant switcher", async ({
+    page,
+  }) => {
+    const songs: any[] = getCachedSongs();
+    const goingMyWay = songs.filter(
+      (song) => song.album === "Going My Way" && song.title === "Going My Way",
+    );
+    const mv = goingMyWay.find((song) =>
+      (song.tags ?? []).some((tag: string) => tag.includes("MV")),
+    );
+    const artTrack = goingMyWay.find((song) =>
+      (song.tags ?? []).includes("アートトラック"),
+    );
+    test.skip(!mv || !artTrack, "Going My Way MV/art track fixtures missing");
+
+    await page.goto("/discography/album/going-my-way", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(
+      page.getByRole("heading", { name: "Going My Way" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const rows = page.locator("section article").filter({
+      has: page.getByRole("link", { name: "Going My Way" }),
+    });
+    await expect(rows).toHaveCount(1);
+
+    const row = rows.first();
+    await expect(row.getByTestId("album-release-variant-0")).toBeVisible();
+    await expect(
+      row.locator(`a[href="https://www.youtube.com/watch?v=${mv.video_id}"]`),
+    ).toBeVisible();
+
+    await row.getByText("アートトラック").click();
+    await expect(
+      row.locator(
+        `a[href="https://www.youtube.com/watch?v=${artTrack.video_id}"]`,
+      ),
+    ).toBeVisible();
   });
 
   test("discography slug page shows details", async ({ page }) => {

--- a/e2e/discography.spec.ts
+++ b/e2e/discography.spec.ts
@@ -95,6 +95,153 @@ test.describe("Discography page", () => {
     ).toBeVisible();
   });
 
+  test("album page groups multiple MV variants without album", async ({
+    page,
+  }) => {
+    const songs: any[] = getCachedSongs();
+    const mvVariants = songs
+      .filter(
+        (song) =>
+          song.title === "from A to Z" &&
+          song.artist === "AZKi" &&
+          !song.album &&
+          (song.tags ?? []).some((tag: string) => tag.includes("MV")),
+      )
+      .sort((left, right) => {
+        const leftOrder = left.source_order ?? Number.MAX_SAFE_INTEGER;
+        const rightOrder = right.source_order ?? Number.MAX_SAFE_INTEGER;
+        return leftOrder - rightOrder;
+      });
+    test.skip(
+      mvVariants.length < 2,
+      "from A to Z multiple MV fixtures missing",
+    );
+
+    await page.goto("/discography/album/from-a-to-z", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(
+      page.getByRole("heading", { name: "from A to Z" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const rows = page.locator("section article").filter({
+      has: page.getByRole("link", { name: "from A to Z" }),
+    });
+    await expect(rows).toHaveCount(1);
+
+    const row = rows.first();
+    await expect(row.getByText("MV①")).toBeVisible();
+    await expect(row.getByText("MV②")).toBeVisible();
+    await expect(
+      row.locator(
+        `a[href="https://www.youtube.com/watch?v=${mvVariants[0].video_id}"]`,
+      ),
+    ).toBeVisible();
+
+    await row.getByText("MV②").click();
+    await expect(
+      row.locator(
+        `a[href="https://www.youtube.com/watch?v=${mvVariants[1].video_id}"]`,
+      ),
+    ).toBeVisible();
+  });
+
+  test("album page groups AniAZ with original MV across album boundary", async ({
+    page,
+  }) => {
+    const songs: any[] = getCachedSongs();
+    const nekoVariants = songs.filter(
+      (song) =>
+        song.title === "猫ならばいける" &&
+        song.artist === "AZKi" &&
+        (song.tags ?? []).some((tag: string) => tag.includes("MV")),
+    );
+    const originalMv = nekoVariants.find(
+      (song) => !(song.tags ?? []).includes("アニAZ"),
+    );
+    const animatedMv = nekoVariants.find((song) =>
+      (song.tags ?? []).includes("アニAZ"),
+    );
+    test.skip(
+      !originalMv || !animatedMv,
+      "猫ならばいける MV/AniAZ fixtures missing",
+    );
+
+    await page.goto(
+      `/discography/album/${encodeURIComponent("猫ならばいける")}`,
+      {
+        waitUntil: "domcontentloaded",
+      },
+    );
+
+    await expect(
+      page.getByRole("heading", { name: "猫ならばいける" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const rows = page.locator("section article").filter({
+      has: page.getByRole("link", { name: "猫ならばいける" }),
+    });
+    await expect(rows).toHaveCount(1);
+
+    const row = rows.first();
+    await expect(row.getByText("MV", { exact: true })).toBeVisible();
+    await expect(row.getByText("アニAZ", { exact: true })).toBeVisible();
+    await expect(
+      row.locator(
+        `a[href="https://www.youtube.com/watch?v=${originalMv.video_id}"]`,
+      ),
+    ).toBeVisible();
+
+    await row.getByText("アニAZ", { exact: true }).click();
+    await expect(
+      row.locator(
+        `a[href="https://www.youtube.com/watch?v=${animatedMv.video_id}"]`,
+      ),
+    ).toBeVisible();
+  });
+
+  test("song detail breadcrumbs point to virtual release album pages", async ({
+    page,
+  }) => {
+    const songs: any[] = getCachedSongs();
+    const fromAToZ = songs.find(
+      (song) =>
+        song.title === "from A to Z" &&
+        song.artist === "AZKi" &&
+        !song.album &&
+        (song.tags ?? []).some((tag: string) => tag.includes("MV")),
+    );
+    const nekoAniAz = songs.find(
+      (song) =>
+        song.title === "猫ならばいける" &&
+        song.artist === "AZKi" &&
+        (song.tags ?? []).includes("アニAZ"),
+    );
+    test.skip(
+      !fromAToZ || !nekoAniAz,
+      "from A to Z / 猫ならばいける fixtures missing",
+    );
+
+    await page.goto(
+      `/discography/originals/${encodeURIComponent(fromAToZ.slugv2 ?? fromAToZ.slug)}`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(
+      page.locator('a[href="/discography/album/from-a-to-z"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.goto(
+      `/discography/originals/${encodeURIComponent(nekoAniAz.slugv2 ?? nekoAniAz.slug)}`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(
+      page.locator(
+        `a[href="/discography/album/${encodeURIComponent("猫ならばいける")}"]`,
+      ),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
   test("discography slug page shows details", async ({ page }) => {
     const songs: any[] = getCachedSongs();
     const withSlug = songs.find(

--- a/src/app/components/YoutubeThumbnail.tsx
+++ b/src/app/components/YoutubeThumbnail.tsx
@@ -65,9 +65,12 @@ const YoutubeThumbnail: React.FC<YoutubeThumbnailProps> = ({
     setLoading(false);
   };
 
+  // sddefault が含まれる場合はスケールさせる
+  const isSdDefault = imageUrl.includes("sddefault");
+
   return (
     <div
-      className={`relative flex w-full h-full items-center justify-center aspect-video ${
+      className={`relative flex w-full h-full items-center justify-center aspect-video bg-black ${
         outcontainerClassName || ""
       } ${className || ""}`}
     >
@@ -76,21 +79,30 @@ const YoutubeThumbnail: React.FC<YoutubeThumbnailProps> = ({
         className="absolute inset-0 h-full w-full"
         radius={0}
       >
-        <img
-          key={videoId}
-          ref={imageRef}
-          src={imageUrl}
-          alt={alt}
-          className={`absolute inset-0 h-full w-full object-cover outfit-image ${imageClassName || ""}`}
-          loading="lazy"
-          decoding="async"
-          onLoad={handleOnLoad}
-          onError={handleError}
-          style={{
-            opacity: loading ? 0 : 1,
-            transition: "opacity 0.5s",
-          }}
-        />
+        <picture className="absolute inset-0 h-full w-full block">
+          {imageUrl && imageUrl.endsWith(".webp") && (
+            <source srcSet={imageUrl} type="image/webp" />
+          )}
+          <img
+            key={videoId}
+            ref={imageRef}
+            src={imageUrl
+              .replace(".webp", ".jpg")
+              .replace("i.ytimg.com/vi_webp/", "img.youtube.com/vi/")}
+            alt={alt}
+            className={`absolute inset-0 h-full w-full object-cover object-center outfit-image${
+              isSdDefault ? "scale-[1.33] object-left" : ""
+            } ${imageClassName || ""}`}
+            loading="lazy"
+            decoding="async"
+            onLoad={handleOnLoad}
+            onError={handleError}
+            style={{
+              opacity: loading ? 0 : 1,
+              transition: "opacity 0.5s",
+            }}
+          />
+        </picture>
       </Skeleton>
     </div>
   );

--- a/src/app/discography/SongDetails.tsx
+++ b/src/app/discography/SongDetails.tsx
@@ -8,174 +8,12 @@ import { FaYoutube, FaDatabase } from "react-icons/fa6";
 import YoutubeThumbnail from "../components/YoutubeThumbnail";
 import { StatisticsItem } from "./createStatistics";
 import { isCollaborationSong, isPossibleOriginalSong } from "../config/filters";
-import { getCollabUnitName } from "../config/collabUnits";
+import { getCollabMembers, getCollabUnitName } from "../config/collabUnits";
 import slugify from "../lib/slugify";
 import { useTranslations, useLocale } from "next-intl";
 import { formatDate } from "../lib/formatDate";
 import { normalizeSongTitle } from "./utils/normalizeSongTitle";
 import { getAlbumPlaylistUrl } from "./utils/albumLinks";
-import ReleaseVariantSwitcher from "./components/ReleaseVariantSwitcher";
-import {
-  findReleaseVariantByInstanceKey,
-  getSongInstanceKey,
-  groupReleaseVariants,
-  type ReleaseVariantGroup,
-} from "./utils/releaseVariants";
-
-function SongDetailsVideoRow({
-  group,
-  index,
-  isAlbum,
-  t,
-  locale,
-  onPreview,
-}: {
-  group: ReleaseVariantGroup;
-  index: number;
-  isAlbum: boolean;
-  t: ReturnType<typeof useTranslations>;
-  locale: string;
-  onPreview: (videoId: string | null) => void;
-}) {
-  const defaultInstanceKey = getSongInstanceKey(group.representative);
-  const [selectedInstanceKey, setSelectedInstanceKey] =
-    useState(defaultInstanceKey);
-  const selectedSong =
-    findReleaseVariantByInstanceKey(group.variants, selectedInstanceKey) ??
-    group.representative;
-  const resolvedInstanceKey = getSongInstanceKey(selectedSong);
-
-  useEffect(() => {
-    if (!findReleaseVariantByInstanceKey(group.variants, selectedInstanceKey)) {
-      setSelectedInstanceKey(defaultInstanceKey);
-    }
-  }, [defaultInstanceKey, group.variants, selectedInstanceKey]);
-
-  const handleVariantChange = (nextInstanceKey: string) => {
-    setSelectedInstanceKey(nextInstanceKey);
-    const nextSong =
-      findReleaseVariantByInstanceKey(group.variants, nextInstanceKey) ??
-      selectedSong;
-    if (!isAlbum) {
-      onPreview(nextSong.video_id);
-    }
-  };
-
-  const watchHref = selectedSong.tags.includes("カバー曲")
-    ? `/watch?q=tag:カバー曲&v=${selectedSong.video_id}${
-        Number(selectedSong.start ?? 0) > 0 ? `&t=${selectedSong.start}` : ""
-      }`
-    : `/watch?q=tag:オリ曲|album:${selectedSong.album}&v=${selectedSong.video_id}`;
-  const detailHref = selectedSong.album
-    ? `/discography/album/${encodeURIComponent(slugify(selectedSong.album))}`
-    : `/discography/${
-        isPossibleOriginalSong(selectedSong)
-          ? "originals"
-          : isCollaborationSong(selectedSong)
-            ? "collaborations"
-            : "covers"
-      }/${selectedSong.slugv2 ?? encodeURIComponent(selectedSong.video_id)}`;
-
-  return (
-    <Table.Tr
-      key={`${group.key}-${index}`}
-      className="odd:bg-white even:bg-gray-50/50 dark:odd:bg-gray-800 dark:even:bg-gray-700"
-      onMouseEnter={() => {
-        if (!isAlbum) {
-          onPreview(selectedSong.video_id);
-        }
-      }}
-      onMouseLeave={() => {
-        if (!isAlbum) {
-          onPreview(null);
-        }
-      }}
-    >
-      <Table.Td className="dark:text-light-gray-500">
-        <Link
-          href={watchHref}
-          className=" hover:text-primary-600 dark:hover:text-white"
-        >
-          <BsPlayCircle size={24} />
-        </Link>
-      </Table.Td>
-      <Table.Td>
-        <div className="flex flex-col items-start gap-2">
-          <Link
-            href={detailHref}
-            className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500"
-          >
-            {selectedSong.title}
-          </Link>
-          <ReleaseVariantSwitcher
-            variants={group.variants}
-            value={resolvedInstanceKey}
-            onChange={handleVariantChange}
-          />
-        </div>
-      </Table.Td>
-      <Table.Td>
-        <Link
-          href={`/?q=artist:${selectedSong.artist}`}
-          className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500"
-        >
-          {selectedSong.artist}
-        </Link>
-      </Table.Td>
-      <Table.Td>
-        {selectedSong.lyricist &&
-          selectedSong.lyricist
-            .split("、")
-            .map((n: string, i: number, arr: string[]) => (
-              <span key={i}>
-                <Link
-                  href={`/?q=lyricist:${n}`}
-                  className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
-                >
-                  {n}
-                </Link>
-                {i < arr.length - 1 ? "、" : ""}
-              </span>
-            ))}
-      </Table.Td>
-      <Table.Td>
-        {selectedSong.composer &&
-          selectedSong.composer
-            .split("、")
-            .map((n: string, i: number, arr: string[]) => (
-              <span key={i}>
-                <Link
-                  href={`/?q=composer:${n}`}
-                  className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
-                >
-                  {n}
-                </Link>
-                {i < arr.length - 1 ? "、" : ""}
-              </span>
-            ))}
-      </Table.Td>
-      <Table.Td>
-        {selectedSong.arranger &&
-          selectedSong.arranger
-            .split("、")
-            .map((n: string, i: number, arr: string[]) => (
-              <span key={i}>
-                <Link
-                  href={`/?q=arranger:${n}`}
-                  className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
-                >
-                  {n}
-                </Link>
-                {i < arr.length - 1 ? "、" : ""}
-              </span>
-            ))}
-      </Table.Td>
-      <Table.Td className="dark:text-light-gray-500">
-        {formatDate(selectedSong.broadcast_at, locale)}
-      </Table.Td>
-    </Table.Tr>
-  );
-}
 
 const SongDetails = ({ song }: { song: StatisticsItem }) => {
   const t = useTranslations("Discography");
@@ -187,14 +25,25 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
   );
 
   const rawVideos = song.videos || [];
-  const variantGroups = useMemo(
-    () => groupReleaseVariants(rawVideos),
-    [rawVideos],
-  );
-  const videos = useMemo(
-    () => variantGroups.map((group) => group.representative),
-    [variantGroups],
-  );
+  const videos = useMemo(() => {
+    const map = new Map<string, any>();
+    for (const v of rawVideos) {
+      const key = v.slugv2 || `${v.video_id}__${Number(v.start ?? 0)}`;
+      if (!map.has(key)) {
+        map.set(key, v);
+      } else {
+        const existing = map.get(key);
+        const existingIsMV = (existing.tags || []).some((t: string) =>
+          t.includes("MV"),
+        );
+        const vIsMV = (v.tags || []).some((t: string) => t.includes("MV"));
+        if (vIsMV && !existingIsMV) {
+          map.set(key, v);
+        }
+      }
+    }
+    return Array.from(map.values());
+  }, [rawVideos]);
   const initialIndex = Math.max(
     0,
     videos.findIndex((v) => v.video_id === song.firstVideo.video_id),
@@ -213,7 +62,7 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
     // videos の sing を "、" で分割して個別のアーティスト名を順序を保ってユニーク化
     const names: string[] = [];
     const seen = new Set<string>();
-    for (const v of rawVideos) {
+    for (const v of videos) {
       const parts = ((v.sing || "") as string)
         .split("、")
         .map((s) => s.trim())
@@ -226,7 +75,7 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
       }
     }
     return names;
-  }, [rawVideos]);
+  }, [videos]);
 
   // スライドショー間隔（ミリ秒）
   const SLIDE_INTERVAL = 5000;
@@ -427,7 +276,7 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
             </p>
           )}
           <p className="text-sm">
-            {t("tracksCount", { count: variantGroups.length })}
+            {t("tracksCount", { count: videos.length })}
           </p>
 
           <div className="mt-4 max-h-62.5 overflow-y-auto">
@@ -454,16 +303,103 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
                 </Table.Tr>
               </Table.Thead>
               <Table.Tbody>
-                {variantGroups.map((group, index) => (
-                  <SongDetailsVideoRow
-                    key={group.key}
-                    group={group}
-                    index={index}
-                    isAlbum={song.isAlbum}
-                    t={t}
-                    locale={locale}
-                    onPreview={setHoveredVideo}
-                  />
+                {videos.map((s, index) => (
+                  <Table.Tr
+                    key={index}
+                    className="odd:bg-white even:bg-gray-50/50 dark:odd:bg-gray-800 dark:even:bg-gray-700"
+                    onMouseEnter={() => {
+                      if (!song.isAlbum) {
+                        setHoveredVideo(s.video_id);
+                      }
+                    }}
+                    onMouseLeave={() => {
+                      if (!song.isAlbum) {
+                        setHoveredVideo(null);
+                      }
+                    }}
+                  >
+                    <Table.Td className="dark:text-light-gray-500">
+                      <Link
+                        href={`${s.tags.includes("カバー曲") ? `/watch?q=tag:カバー曲&v=${s.video_id}${Number(s.start ?? 0) > 0 ? `&t=${s.start}` : ""}` : `/watch?q=tag:オリ曲|album:${s.album}&v=${s.video_id}`}`}
+                        className=" hover:text-primary-600 dark:hover:text-white"
+                      >
+                        <BsPlayCircle size={24} />
+                      </Link>
+                    </Table.Td>
+                    <Table.Td>
+                      <Link
+                        href={
+                          s.album
+                            ? `/discography/album/${encodeURIComponent(slugify(s.album))}`
+                            : `/discography/${isPossibleOriginalSong(s) ? "originals" : isCollaborationSong(s) ? "collaborations" : "covers"}/${
+                                s.slugv2 ?? encodeURIComponent(s.video_id)
+                              }`
+                        }
+                        className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500"
+                      >
+                        {s.title}
+                      </Link>
+                    </Table.Td>
+                    <Table.Td>
+                      <Link
+                        href={`/?q=artist:${s.artist}`}
+                        className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500"
+                      >
+                        {s.artist}
+                      </Link>
+                    </Table.Td>
+                    <Table.Td>
+                      {s.lyricist &&
+                        s.lyricist
+                          .split("、")
+                          .map((n: string, i: number, arr: string[]) => (
+                            <span key={i}>
+                              <Link
+                                href={`/?q=lyricist:${n}`}
+                                className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
+                              >
+                                {n}
+                              </Link>
+                              {i < arr.length - 1 ? "、" : ""}
+                            </span>
+                          ))}
+                    </Table.Td>
+                    <Table.Td>
+                      {s.composer &&
+                        s.composer
+                          .split("、")
+                          .map((n: string, i: number, arr: string[]) => (
+                            <span key={i}>
+                              <Link
+                                href={`/?q=composer:${n}`}
+                                className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
+                              >
+                                {n}
+                              </Link>
+                              {i < arr.length - 1 ? "、" : ""}
+                            </span>
+                          ))}
+                    </Table.Td>
+                    <Table.Td>
+                      {s.arranger &&
+                        s.arranger
+                          .split("、")
+                          .map((n: string, i: number, arr: string[]) => (
+                            <span key={i}>
+                              <Link
+                                href={`/?q=arranger:${n}`}
+                                className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
+                              >
+                                {n}
+                              </Link>
+                              {i < arr.length - 1 ? "、" : ""}
+                            </span>
+                          ))}
+                    </Table.Td>
+                    <Table.Td className="dark:text-light-gray-500">
+                      {formatDate(s.broadcast_at, locale)}
+                    </Table.Td>
+                  </Table.Tr>
                 ))}
               </Table.Tbody>
             </Table>

--- a/src/app/discography/SongDetails.tsx
+++ b/src/app/discography/SongDetails.tsx
@@ -8,12 +8,174 @@ import { FaYoutube, FaDatabase } from "react-icons/fa6";
 import YoutubeThumbnail from "../components/YoutubeThumbnail";
 import { StatisticsItem } from "./createStatistics";
 import { isCollaborationSong, isPossibleOriginalSong } from "../config/filters";
-import { getCollabMembers, getCollabUnitName } from "../config/collabUnits";
+import { getCollabUnitName } from "../config/collabUnits";
 import slugify from "../lib/slugify";
 import { useTranslations, useLocale } from "next-intl";
 import { formatDate } from "../lib/formatDate";
 import { normalizeSongTitle } from "./utils/normalizeSongTitle";
 import { getAlbumPlaylistUrl } from "./utils/albumLinks";
+import ReleaseVariantSwitcher from "./components/ReleaseVariantSwitcher";
+import {
+  findReleaseVariantByInstanceKey,
+  getSongInstanceKey,
+  groupReleaseVariants,
+  type ReleaseVariantGroup,
+} from "./utils/releaseVariants";
+
+function SongDetailsVideoRow({
+  group,
+  index,
+  isAlbum,
+  t,
+  locale,
+  onPreview,
+}: {
+  group: ReleaseVariantGroup;
+  index: number;
+  isAlbum: boolean;
+  t: ReturnType<typeof useTranslations>;
+  locale: string;
+  onPreview: (videoId: string | null) => void;
+}) {
+  const defaultInstanceKey = getSongInstanceKey(group.representative);
+  const [selectedInstanceKey, setSelectedInstanceKey] =
+    useState(defaultInstanceKey);
+  const selectedSong =
+    findReleaseVariantByInstanceKey(group.variants, selectedInstanceKey) ??
+    group.representative;
+  const resolvedInstanceKey = getSongInstanceKey(selectedSong);
+
+  useEffect(() => {
+    if (!findReleaseVariantByInstanceKey(group.variants, selectedInstanceKey)) {
+      setSelectedInstanceKey(defaultInstanceKey);
+    }
+  }, [defaultInstanceKey, group.variants, selectedInstanceKey]);
+
+  const handleVariantChange = (nextInstanceKey: string) => {
+    setSelectedInstanceKey(nextInstanceKey);
+    const nextSong =
+      findReleaseVariantByInstanceKey(group.variants, nextInstanceKey) ??
+      selectedSong;
+    if (!isAlbum) {
+      onPreview(nextSong.video_id);
+    }
+  };
+
+  const watchHref = selectedSong.tags.includes("カバー曲")
+    ? `/watch?q=tag:カバー曲&v=${selectedSong.video_id}${
+        Number(selectedSong.start ?? 0) > 0 ? `&t=${selectedSong.start}` : ""
+      }`
+    : `/watch?q=tag:オリ曲|album:${selectedSong.album}&v=${selectedSong.video_id}`;
+  const detailHref = selectedSong.album
+    ? `/discography/album/${encodeURIComponent(slugify(selectedSong.album))}`
+    : `/discography/${
+        isPossibleOriginalSong(selectedSong)
+          ? "originals"
+          : isCollaborationSong(selectedSong)
+            ? "collaborations"
+            : "covers"
+      }/${selectedSong.slugv2 ?? encodeURIComponent(selectedSong.video_id)}`;
+
+  return (
+    <Table.Tr
+      key={`${group.key}-${index}`}
+      className="odd:bg-white even:bg-gray-50/50 dark:odd:bg-gray-800 dark:even:bg-gray-700"
+      onMouseEnter={() => {
+        if (!isAlbum) {
+          onPreview(selectedSong.video_id);
+        }
+      }}
+      onMouseLeave={() => {
+        if (!isAlbum) {
+          onPreview(null);
+        }
+      }}
+    >
+      <Table.Td className="dark:text-light-gray-500">
+        <Link
+          href={watchHref}
+          className=" hover:text-primary-600 dark:hover:text-white"
+        >
+          <BsPlayCircle size={24} />
+        </Link>
+      </Table.Td>
+      <Table.Td>
+        <div className="flex flex-col items-start gap-2">
+          <Link
+            href={detailHref}
+            className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500"
+          >
+            {selectedSong.title}
+          </Link>
+          <ReleaseVariantSwitcher
+            variants={group.variants}
+            value={resolvedInstanceKey}
+            onChange={handleVariantChange}
+          />
+        </div>
+      </Table.Td>
+      <Table.Td>
+        <Link
+          href={`/?q=artist:${selectedSong.artist}`}
+          className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500"
+        >
+          {selectedSong.artist}
+        </Link>
+      </Table.Td>
+      <Table.Td>
+        {selectedSong.lyricist &&
+          selectedSong.lyricist
+            .split("、")
+            .map((n: string, i: number, arr: string[]) => (
+              <span key={i}>
+                <Link
+                  href={`/?q=lyricist:${n}`}
+                  className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
+                >
+                  {n}
+                </Link>
+                {i < arr.length - 1 ? "、" : ""}
+              </span>
+            ))}
+      </Table.Td>
+      <Table.Td>
+        {selectedSong.composer &&
+          selectedSong.composer
+            .split("、")
+            .map((n: string, i: number, arr: string[]) => (
+              <span key={i}>
+                <Link
+                  href={`/?q=composer:${n}`}
+                  className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
+                >
+                  {n}
+                </Link>
+                {i < arr.length - 1 ? "、" : ""}
+              </span>
+            ))}
+      </Table.Td>
+      <Table.Td>
+        {selectedSong.arranger &&
+          selectedSong.arranger
+            .split("、")
+            .map((n: string, i: number, arr: string[]) => (
+              <span key={i}>
+                <Link
+                  href={`/?q=arranger:${n}`}
+                  className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
+                >
+                  {n}
+                </Link>
+                {i < arr.length - 1 ? "、" : ""}
+              </span>
+            ))}
+      </Table.Td>
+      <Table.Td className="dark:text-light-gray-500">
+        {formatDate(selectedSong.broadcast_at, locale)}
+      </Table.Td>
+    </Table.Tr>
+  );
+}
 
 const SongDetails = ({ song }: { song: StatisticsItem }) => {
   const t = useTranslations("Discography");
@@ -25,25 +187,14 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
   );
 
   const rawVideos = song.videos || [];
-  const videos = useMemo(() => {
-    const map = new Map<string, any>();
-    for (const v of rawVideos) {
-      const key = v.slugv2 || `${v.video_id}__${Number(v.start ?? 0)}`;
-      if (!map.has(key)) {
-        map.set(key, v);
-      } else {
-        const existing = map.get(key);
-        const existingIsMV = (existing.tags || []).some((t: string) =>
-          t.includes("MV"),
-        );
-        const vIsMV = (v.tags || []).some((t: string) => t.includes("MV"));
-        if (vIsMV && !existingIsMV) {
-          map.set(key, v);
-        }
-      }
-    }
-    return Array.from(map.values());
-  }, [rawVideos]);
+  const variantGroups = useMemo(
+    () => groupReleaseVariants(rawVideos),
+    [rawVideos],
+  );
+  const videos = useMemo(
+    () => variantGroups.map((group) => group.representative),
+    [variantGroups],
+  );
   const initialIndex = Math.max(
     0,
     videos.findIndex((v) => v.video_id === song.firstVideo.video_id),
@@ -62,7 +213,7 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
     // videos の sing を "、" で分割して個別のアーティスト名を順序を保ってユニーク化
     const names: string[] = [];
     const seen = new Set<string>();
-    for (const v of videos) {
+    for (const v of rawVideos) {
       const parts = ((v.sing || "") as string)
         .split("、")
         .map((s) => s.trim())
@@ -75,7 +226,7 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
       }
     }
     return names;
-  }, [videos]);
+  }, [rawVideos]);
 
   // スライドショー間隔（ミリ秒）
   const SLIDE_INTERVAL = 5000;
@@ -276,7 +427,7 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
             </p>
           )}
           <p className="text-sm">
-            {t("tracksCount", { count: videos.length })}
+            {t("tracksCount", { count: variantGroups.length })}
           </p>
 
           <div className="mt-4 max-h-62.5 overflow-y-auto">
@@ -303,103 +454,16 @@ const SongDetails = ({ song }: { song: StatisticsItem }) => {
                 </Table.Tr>
               </Table.Thead>
               <Table.Tbody>
-                {videos.map((s, index) => (
-                  <Table.Tr
-                    key={index}
-                    className="odd:bg-white even:bg-gray-50/50 dark:odd:bg-gray-800 dark:even:bg-gray-700"
-                    onMouseEnter={() => {
-                      if (!song.isAlbum) {
-                        setHoveredVideo(s.video_id);
-                      }
-                    }}
-                    onMouseLeave={() => {
-                      if (!song.isAlbum) {
-                        setHoveredVideo(null);
-                      }
-                    }}
-                  >
-                    <Table.Td className="dark:text-light-gray-500">
-                      <Link
-                        href={`${s.tags.includes("カバー曲") ? `/watch?q=tag:カバー曲&v=${s.video_id}${Number(s.start ?? 0) > 0 ? `&t=${s.start}` : ""}` : `/watch?q=tag:オリ曲|album:${s.album}&v=${s.video_id}`}`}
-                        className=" hover:text-primary-600 dark:hover:text-white"
-                      >
-                        <BsPlayCircle size={24} />
-                      </Link>
-                    </Table.Td>
-                    <Table.Td>
-                      <Link
-                        href={
-                          s.album
-                            ? `/discography/album/${encodeURIComponent(slugify(s.album))}`
-                            : `/discography/${isPossibleOriginalSong(s) ? "originals" : isCollaborationSong(s) ? "collaborations" : "covers"}/${
-                                s.slugv2 ?? encodeURIComponent(s.video_id)
-                              }`
-                        }
-                        className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500"
-                      >
-                        {s.title}
-                      </Link>
-                    </Table.Td>
-                    <Table.Td>
-                      <Link
-                        href={`/?q=artist:${s.artist}`}
-                        className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500"
-                      >
-                        {s.artist}
-                      </Link>
-                    </Table.Td>
-                    <Table.Td>
-                      {s.lyricist &&
-                        s.lyricist
-                          .split("、")
-                          .map((n: string, i: number, arr: string[]) => (
-                            <span key={i}>
-                              <Link
-                                href={`/?q=lyricist:${n}`}
-                                className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
-                              >
-                                {n}
-                              </Link>
-                              {i < arr.length - 1 ? "、" : ""}
-                            </span>
-                          ))}
-                    </Table.Td>
-                    <Table.Td>
-                      {s.composer &&
-                        s.composer
-                          .split("、")
-                          .map((n: string, i: number, arr: string[]) => (
-                            <span key={i}>
-                              <Link
-                                href={`/?q=composer:${n}`}
-                                className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
-                              >
-                                {n}
-                              </Link>
-                              {i < arr.length - 1 ? "、" : ""}
-                            </span>
-                          ))}
-                    </Table.Td>
-                    <Table.Td>
-                      {s.arranger &&
-                        s.arranger
-                          .split("、")
-                          .map((n: string, i: number, arr: string[]) => (
-                            <span key={i}>
-                              <Link
-                                href={`/?q=arranger:${n}`}
-                                className="text-primary hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-500 mr-1"
-                              >
-                                {n}
-                              </Link>
-                              {i < arr.length - 1 ? "、" : ""}
-                            </span>
-                          ))}
-                    </Table.Td>
-                    <Table.Td className="dark:text-light-gray-500">
-                      {formatDate(s.broadcast_at, locale)}
-                    </Table.Td>
-                  </Table.Tr>
+                {variantGroups.map((group, index) => (
+                  <SongDetailsVideoRow
+                    key={group.key}
+                    group={group}
+                    index={index}
+                    isAlbum={song.isAlbum}
+                    t={t}
+                    locale={locale}
+                    onPreview={setHoveredVideo}
+                  />
                 ))}
               </Table.Tbody>
             </Table>

--- a/src/app/discography/SongItem.tsx
+++ b/src/app/discography/SongItem.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations, useLocale } from "next-intl";
 import { formatDate } from "../lib/formatDate";
 import { normalizeSongTitle } from "./utils/normalizeSongTitle";
+import { groupReleaseVariants } from "./utils/releaseVariants";
 
 const SongItem = ({
   song,
@@ -53,6 +54,17 @@ const SongItem = ({
   };
 
   const handleClick = () => {
+    const releaseGroups = groupReleaseVariants(song.videos ?? []);
+    const hasSingleReleaseVariantGroup =
+      releaseGroups.length === 1 && releaseGroups[0].variants.length > 1;
+    if (hasSingleReleaseVariantGroup) {
+      const releaseSlug = slugify(releaseGroups[0].representative.title);
+      if (releaseSlug) {
+        router.push(`/discography/album/${encodeURIComponent(releaseSlug)}`);
+        return;
+      }
+    }
+
     if (song.isAlbum && groupByAlbum && albumSlug) {
       router.push(`/discography/album/${encodeURIComponent(albumSlug)}`);
       return;

--- a/src/app/discography/[category]/AlbumClient.tsx
+++ b/src/app/discography/[category]/AlbumClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Link } from "@/i18n/navigation";
 import { Song } from "../../types/song";
 import { FaDatabase, FaPlay, FaYoutube } from "react-icons/fa6";
@@ -17,6 +18,13 @@ import { formatDate } from "../../lib/formatDate";
 import { siteConfig } from "@/app/config/siteConfig";
 import { pageClasses } from "@/app/theme";
 import { getAlbumPlaylistUrl } from "../utils/albumLinks";
+import ReleaseVariantSwitcher from "../components/ReleaseVariantSwitcher";
+import {
+  findReleaseVariantByInstanceKey,
+  getSongInstanceKey,
+  groupReleaseVariants,
+  type ReleaseVariantGroup,
+} from "../utils/releaseVariants";
 
 function resolveSongCategory(
   song: Song,
@@ -43,6 +51,110 @@ function getCategoryBreadcrumb(song: Song): { labelKey: string; href: string } {
   return { labelKey: "coversLabel", href: "/discography/covers" };
 }
 
+function AlbumSongRow({
+  group,
+  index,
+  t,
+  tWatchDetail,
+  locale,
+}: {
+  group: ReleaseVariantGroup;
+  index: number;
+  t: ReturnType<typeof useTranslations>;
+  tWatchDetail: ReturnType<typeof useTranslations>;
+  locale: string;
+}) {
+  const defaultInstanceKey = getSongInstanceKey(group.representative);
+  const [selectedInstanceKey, setSelectedInstanceKey] =
+    useState(defaultInstanceKey);
+  const selectedSong =
+    findReleaseVariantByInstanceKey(group.variants, selectedInstanceKey) ??
+    group.representative;
+  const resolvedInstanceKey = getSongInstanceKey(selectedSong);
+
+  useEffect(() => {
+    if (!findReleaseVariantByInstanceKey(group.variants, selectedInstanceKey)) {
+      setSelectedInstanceKey(defaultInstanceKey);
+    }
+  }, [defaultInstanceKey, group.variants, selectedInstanceKey]);
+
+  return (
+    <article className="rounded-xl bg-light-gray-100 dark:bg-gray-700 p-3 md:p-4">
+      <div className="flex items-start gap-3 min-w-0">
+        <span className="shrink-0 text-sm font-semibold text-gray-600 dark:text-light-gray-500 w-10">
+          #{index + 1}
+        </span>
+
+        <div className="w-32 shrink-0 overflow-hidden rounded aspect-video">
+          <YoutubeThumbnail
+            videoId={selectedSong.video_id}
+            alt={selectedSong.title}
+            imageClassName="object-cover"
+          />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <Link
+                href={buildSongDetailPath(selectedSong)}
+                className="block text-base font-semibold text-gray-900 dark:text-white hover:text-primary-500 dark:hover:text-primary-400 wrap-break-word leading-snug"
+              >
+                {selectedSong.title}
+              </Link>
+              <p className="text-sm text-gray-700 dark:text-light-gray-500 wrap-break-word leading-snug">
+                {selectedSong.artist}
+              </p>
+            </div>
+            <ReleaseVariantSwitcher
+              variants={group.variants}
+              value={resolvedInstanceKey}
+              onChange={setSelectedInstanceKey}
+              testId={`album-release-variant-${index}`}
+            />
+          </div>
+
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Link
+              href={`https://www.youtube.com/watch?v=${selectedSong.video_id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 hover:bg-red-700 text-white text-xs font-semibold px-2.5 py-1.5 leading-none"
+            >
+              <FaYoutube className="text-xs" /> {t("buttons.watchOnYouTube")}
+            </Link>
+            <Link
+              href={`/watch?v=${selectedSong.video_id}&q=album:${encodeURIComponent(selectedSong.album ?? "")}`}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary-600 hover:bg-primary-700 text-white text-xs font-semibold px-2.5 py-1.5 leading-none"
+            >
+              <FaPlay className="text-xs" /> {t("buttons.play")}
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-1 text-xs text-gray-600 dark:text-light-gray-500 flex flex-wrap items-center gap-x-4 gap-y-1 pl-13 md:pl-14">
+        <span>
+          {tWatchDetail("singers") || "歌:"} {selectedSong.sing || "-"}
+        </span>
+        <span>
+          {tWatchDetail("lyricist") || "作詞"}: {selectedSong.lyricist || "-"}
+        </span>
+        <span>
+          {tWatchDetail("composer") || "作曲"}: {selectedSong.composer || "-"}
+        </span>
+        <span>
+          {tWatchDetail("arranger") || "編曲"}: {selectedSong.arranger || "-"}
+        </span>
+        <span>
+          {tWatchDetail("broadcastDate") || "動画公開日:"}{" "}
+          {formatDate(selectedSong.broadcast_at, locale)}
+        </span>
+      </div>
+    </article>
+  );
+}
+
 export default function AlbumClient({
   albumName,
   coverVideoId,
@@ -58,29 +170,27 @@ export default function AlbumClient({
   const tWatchDetail = useTranslations("Watch.nowPlayingSongInfoDetail");
   const tWatch = useTranslations("Watch.nowPlayingSongInfo");
   const songs: Song[] = allSongs ?? [];
-  const albumSongs = Array.from(
-    new Map(
-      songs
-        .filter(
-          (song) => song.album && song.video_id && song.album === albumName,
-        )
-        .map((song) => [song.video_id, song]),
-    ).values(),
-  ).sort((left, right) => {
-    const leftOrder = left.source_order ?? Number.MAX_SAFE_INTEGER;
-    const rightOrder = right.source_order ?? Number.MAX_SAFE_INTEGER;
-    return leftOrder - rightOrder;
-  });
+  const rawAlbumSongs = songs
+    .filter((song) => song.album && song.video_id && song.album === albumName)
+    .sort((left, right) => {
+      const leftOrder = left.source_order ?? Number.MAX_SAFE_INTEGER;
+      const rightOrder = right.source_order ?? Number.MAX_SAFE_INTEGER;
+      return leftOrder - rightOrder;
+    });
+  const albumSongGroups = groupReleaseVariants(rawAlbumSongs);
   const leadSong =
-    albumSongs.find((song) => song.video_id === coverVideoId) ?? albumSongs[0];
-  const albumArtists = albumSongs
-    .map((song) => song.artist?.trim())
+    albumSongGroups.find((group) =>
+      group.variants.some((song) => song.video_id === coverVideoId),
+    )?.representative ?? albumSongGroups[0]?.representative;
+  const albumArtists = albumSongGroups
+    .map((group) => group.representative.artist?.trim())
     .filter((artist): artist is string => Boolean(artist));
   const hasSingleAlbumArtist =
     albumArtists.length > 0 && new Set(albumArtists).size === 1;
   const isCoverAlbum = hasSingleAlbumArtist
     ? false
-    : albumSongs.some((song) => {
+    : albumSongGroups.some((group) => {
+        const song = group.representative;
         const artist = song.artist?.trim();
         const singer = song.sing?.trim();
         if (!artist || !singer) return false;
@@ -95,7 +205,7 @@ export default function AlbumClient({
     );
   }
 
-  if (albumSongs.length === 0) {
+  if (albumSongGroups.length === 0) {
     return (
       <div className={pageClasses.shell}>
         <h1 className="text-2xl font-bold">
@@ -108,7 +218,7 @@ export default function AlbumClient({
   if (!leadSong) {
     return null;
   }
-  const updatedAt = albumSongs
+  const updatedAt = rawAlbumSongs
     .map((song) => new Date(song.broadcast_at).getTime())
     .filter((ts) => !Number.isNaN(ts))
     .sort((a, b) => b - a)[0];
@@ -150,7 +260,7 @@ export default function AlbumClient({
             {formatDate(leadSong.album_release_at, locale)}
           </p>
           <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
-            {t("tracksCount", { count: albumSongs.length })}
+            {t("tracksCount", { count: albumSongGroups.length })}
           </p>
           {updatedAt && (
             <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
@@ -183,74 +293,15 @@ export default function AlbumClient({
 
         <section className="rounded-sm bg-gray-50/20 dark:bg-gray-800 p-2 md:p-0">
           <div className="space-y-3">
-            {albumSongs.map((song, index) => (
-              <article
-                key={`${song.video_id}-${index}`}
-                className="rounded-xl bg-light-gray-100 dark:bg-gray-700 p-3 md:p-4"
-              >
-                <div className="flex items-start gap-3 min-w-0">
-                  <span className="shrink-0 text-sm font-semibold text-gray-600 dark:text-light-gray-500 w-10">
-                    #{index + 1}
-                  </span>
-
-                  <div className="w-32 shrink-0 overflow-hidden rounded aspect-video">
-                    <YoutubeThumbnail
-                      videoId={song.video_id}
-                      alt={song.title}
-                      imageClassName="object-cover"
-                    />
-                  </div>
-
-                  <div className="min-w-0 flex-1">
-                    <Link
-                      href={buildSongDetailPath(song)}
-                      className="block text-base font-semibold text-gray-900 dark:text-white hover:text-primary-500 dark:hover:text-primary-400 wrap-break-word leading-snug"
-                    >
-                      {song.title}
-                    </Link>
-                    <p className="text-sm text-gray-700 dark:text-light-gray-500 wrap-break-word leading-snug">
-                      {song.artist}
-                    </p>
-
-                    <div className="mt-2 flex flex-wrap items-center gap-2">
-                      <Link
-                        href={`https://www.youtube.com/watch?v=${song.video_id}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 hover:bg-red-700 text-white text-xs font-semibold px-2.5 py-1.5 leading-none"
-                      >
-                        <FaYoutube className="text-xs" />{" "}
-                        {t("buttons.watchOnYouTube")}
-                      </Link>
-                      <Link
-                        href={`/watch?v=${song.video_id}&q=album:${encodeURIComponent(song.album ?? "")}`}
-                        className="inline-flex items-center gap-1.5 rounded-lg bg-primary-600 hover:bg-primary-700 text-white text-xs font-semibold px-2.5 py-1.5 leading-none"
-                      >
-                        <FaPlay className="text-xs" /> {t("buttons.play")}
-                      </Link>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="mt-1 text-xs text-gray-600 dark:text-light-gray-500 flex flex-wrap items-center gap-x-4 gap-y-1 pl-13 md:pl-14">
-                  <span>
-                    {tWatchDetail("singers") || "歌:"} {song.sing || "-"}
-                  </span>
-                  <span>
-                    {tWatchDetail("lyricist") || "作詞"}: {song.lyricist || "-"}
-                  </span>
-                  <span>
-                    {tWatchDetail("composer") || "作曲"}: {song.composer || "-"}
-                  </span>
-                  <span>
-                    {tWatchDetail("arranger") || "編曲"}: {song.arranger || "-"}
-                  </span>
-                  <span>
-                    {tWatchDetail("broadcastDate") || "動画公開日:"}{" "}
-                    {formatDate(song.broadcast_at, locale)}
-                  </span>
-                </div>
-              </article>
+            {albumSongGroups.map((group, index) => (
+              <AlbumSongRow
+                key={group.key}
+                group={group}
+                index={index}
+                t={t}
+                tWatchDetail={tWatchDetail}
+                locale={locale}
+              />
             ))}
           </div>
         </section>

--- a/src/app/discography/[category]/AlbumClient.tsx
+++ b/src/app/discography/[category]/AlbumClient.tsx
@@ -23,6 +23,7 @@ import {
   findReleaseVariantByInstanceKey,
   getSongInstanceKey,
   groupReleaseVariants,
+  matchesReleaseVariantGroupKey,
   type ReleaseVariantGroup,
 } from "../utils/releaseVariants";
 
@@ -158,9 +159,11 @@ function AlbumSongRow({
 export default function AlbumClient({
   albumName,
   coverVideoId,
+  releaseGroupKey,
 }: {
   albumName: string;
   coverVideoId?: string;
+  releaseGroupKey?: string;
 }) {
   const { allSongs, isLoading } = useSongs();
   const t = useTranslations("Discography");
@@ -171,7 +174,11 @@ export default function AlbumClient({
   const tWatch = useTranslations("Watch.nowPlayingSongInfo");
   const songs: Song[] = allSongs ?? [];
   const rawAlbumSongs = songs
-    .filter((song) => song.album && song.video_id && song.album === albumName)
+    .filter((song) =>
+      releaseGroupKey
+        ? song.video_id && matchesReleaseVariantGroupKey(song, releaseGroupKey)
+        : song.album && song.video_id && song.album === albumName,
+    )
     .sort((left, right) => {
       const leftOrder = left.source_order ?? Number.MAX_SAFE_INTEGER;
       const rightOrder = right.source_order ?? Number.MAX_SAFE_INTEGER;

--- a/src/app/discography/[category]/[slug]/ClientPage.tsx
+++ b/src/app/discography/[category]/[slug]/ClientPage.tsx
@@ -8,7 +8,7 @@ import { findRouteForRelease } from "../../../config/timelineRoutes";
 import { findVisualForRelease } from "../../../config/timelineVisuals";
 import { FaPlay, FaXTwitter, FaYoutube } from "react-icons/fa6";
 import { Badge, LoadingOverlay, Modal } from "@mantine/core";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { formatDate } from "../../../lib/formatDate";
 import { renderLinkedText } from "../../../lib/textLinkify";
@@ -19,6 +19,106 @@ import { getCollabUnitName } from "@/app/config/collabUnits";
 import DiscographyBreadcrumbs from "../../components/DiscographyBreadcrumbs";
 import YoutubeThumbnail from "@/app/components/YoutubeThumbnail";
 import { pageClasses } from "@/app/theme";
+import ReleaseVariantSwitcher from "../../components/ReleaseVariantSwitcher";
+import {
+  chooseReleaseRepresentative,
+  findReleaseVariantByInstanceKey,
+  getReleaseVariantGroupKey,
+  getSongInstanceKey,
+  groupReleaseVariants,
+  type ReleaseVariantGroup,
+} from "../../utils/releaseVariants";
+
+function RelatedVideoCard({
+  group,
+  category,
+  locale,
+  showPublishedDate = false,
+}: {
+  group: ReleaseVariantGroup;
+  category: string;
+  locale: string;
+  showPublishedDate?: boolean;
+}) {
+  const t = useTranslations("Discography");
+  const defaultInstanceKey = getSongInstanceKey(group.representative);
+  const [selectedInstanceKey, setSelectedInstanceKey] =
+    useState(defaultInstanceKey);
+  const selectedSong =
+    findReleaseVariantByInstanceKey(group.variants, selectedInstanceKey) ??
+    group.representative;
+  const resolvedInstanceKey = getSongInstanceKey(selectedSong);
+  const internalHref = selectedSong.slugv2
+    ? `/discography/${category}/${encodeURIComponent(selectedSong.slugv2)}`
+    : selectedSong.title
+      ? `/discography/${category}/${encodeURIComponent(slugify(selectedSong.title))}`
+      : "#";
+
+  useEffect(() => {
+    if (!findReleaseVariantByInstanceKey(group.variants, selectedInstanceKey)) {
+      setSelectedInstanceKey(defaultInstanceKey);
+    }
+  }, [defaultInstanceKey, group.variants, selectedInstanceKey]);
+
+  return (
+    <div className="flex items-center gap-3 rounded-md overflow-hidden bg-gray-50/20 dark:bg-gray-800 p-2">
+      <div className="w-28 h-16 overflow-hidden rounded">
+        <YoutubeThumbnail
+          videoId={selectedSong.video_id}
+          alt={selectedSong.video_title}
+          className="w-full h-full"
+          imageClassName="object-cover"
+        />
+      </div>
+      <div className="text-sm flex-1 min-w-0">
+        <div className="font-medium wrap-break-word">
+          {showPublishedDate ? (
+            selectedSong.video_title
+          ) : (
+            <Link href={internalHref}>{selectedSong.title}</Link>
+          )}
+        </div>
+        <div className="text-xs text-gray-600 dark:text-gray-300">
+          {showPublishedDate
+            ? `${t("labels.publishedDate")} ${formatDate(
+                selectedSong.broadcast_at,
+                locale,
+              )}`
+            : `${selectedSong.artist} - ${selectedSong.sing}`}
+        </div>
+        <ReleaseVariantSwitcher
+          variants={group.variants}
+          value={resolvedInstanceKey}
+          onChange={setSelectedInstanceKey}
+          className="mt-2"
+        />
+        <div className="mt-2 flex flex-wrap gap-2">
+          <a
+            href={`https://www.youtube.com/watch?v=${selectedSong.video_id}${
+              showPublishedDate && Number(selectedSong.start) > 0
+                ? `&t=${selectedSong.start}s`
+                : ""
+            }`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block bg-red-600 text-white py-1 px-3 rounded-md text-xs"
+          >
+            <FaYoutube className="inline mr-1 -mt-1" />{" "}
+            {t("buttons.watchOnYouTube")}
+          </a>
+          <Link
+            href={`/watch?q=video_id:${selectedSong.video_id}&v=${selectedSong.video_id}${
+              Number(selectedSong.start) > 0 ? `&t=${selectedSong.start}` : ""
+            }`}
+            className="inline-block bg-primary-600 text-white py-1 px-3 rounded-md text-xs"
+          >
+            <FaPlay className="inline mr-1 -mt-1" /> {t("buttons.play")}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function ClientPage({
   category,
@@ -31,6 +131,58 @@ export default function ClientPage({
   const locale = useLocale();
   const { allSongs, isLoading } = useSongs();
   const [thumbnailModalOpen, setThumbnailModalOpen] = useState(false);
+  const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>(
+    null,
+  );
+
+  const songs: Song[] = allSongs ?? [];
+  const matched = useMemo(
+    () =>
+      songs.filter(
+        (s) =>
+          s.slug === slug ||
+          s.slugv2 === slug ||
+          (s.album && slugify(s.album) === slug),
+      ),
+    [slug, songs],
+  );
+  const preferredMatchedSong = useMemo(
+    () => chooseReleaseRepresentative(matched) ?? null,
+    [matched],
+  );
+  const currentVariantGroup = useMemo(() => {
+    if (!preferredMatchedSong) return null;
+    const groupKey = getReleaseVariantGroupKey(preferredMatchedSong);
+    return (
+      groupReleaseVariants(
+        songs.filter((song) => getReleaseVariantGroupKey(song) === groupKey),
+      )[0] ?? null
+    );
+  }, [preferredMatchedSong, songs]);
+  const song =
+    currentVariantGroup &&
+    findReleaseVariantByInstanceKey(
+      currentVariantGroup.variants,
+      selectedVariantKey,
+    )
+      ? findReleaseVariantByInstanceKey(
+          currentVariantGroup.variants,
+          selectedVariantKey,
+        )
+      : (currentVariantGroup?.representative ?? preferredMatchedSong);
+
+  useEffect(() => {
+    if (!currentVariantGroup) return;
+    const resolvedSelected = findReleaseVariantByInstanceKey(
+      currentVariantGroup.variants,
+      selectedVariantKey,
+    );
+    if (!resolvedSelected) {
+      setSelectedVariantKey(
+        getSongInstanceKey(currentVariantGroup.representative),
+      );
+    }
+  }, [currentVariantGroup, selectedVariantKey]);
 
   if (isLoading) {
     return (
@@ -40,14 +192,6 @@ export default function ClientPage({
     );
   }
 
-  const songs: Song[] = allSongs ?? [];
-  const matched = songs.filter(
-    (s) =>
-      s.slug === slug ||
-      s.slugv2 === slug ||
-      (s.album && slugify(s.album) === slug),
-  );
-
   if (!matched || matched.length === 0) {
     return (
       <div className={pageClasses.shell}>
@@ -56,16 +200,6 @@ export default function ClientPage({
       </div>
     );
   }
-
-  const includeMVTagged = matched.some((s) =>
-    s.tags?.some((t) => t.includes("MV")),
-  );
-  const song =
-    matched.length > 1
-      ? includeMVTagged
-        ? matched.find((s) => s.tags?.some((t) => t.includes("MV")))
-        : matched[0]
-      : matched[0];
 
   if (!song) {
     return (
@@ -88,8 +222,9 @@ export default function ClientPage({
       song.album &&
       s.album === song.album &&
       s.video_id &&
-      s.video_id !== song.video_id,
+      getReleaseVariantGroupKey(s) !== getReleaseVariantGroupKey(song),
   );
+  const relatedAlbumGroups = groupReleaseVariants(relatedAlbum);
 
   const relatedSameTitle = songs.filter(
     (s: Song) =>
@@ -100,6 +235,7 @@ export default function ClientPage({
       s.video_id !== song.video_id &&
       s.tags?.some((t) => t.includes("歌枠")),
   );
+  const relatedSameTitleGroups = groupReleaseVariants(relatedSameTitle);
 
   const unitName = getCollabUnitName(song.sing.split("、"));
 
@@ -187,6 +323,14 @@ export default function ClientPage({
           <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
             {song.artist}
           </p>
+          {currentVariantGroup && (
+            <ReleaseVariantSwitcher
+              variants={currentVariantGroup.variants}
+              value={getSongInstanceKey(song)}
+              onChange={setSelectedVariantKey}
+              className="mb-4"
+            />
+          )}
 
           {song.lyricist && (
             <p className="text-sm">
@@ -329,123 +473,41 @@ export default function ClientPage({
           </div>
 
           <div>
-            {relatedAlbum && relatedAlbum.length > 0 && (
+            {relatedAlbumGroups.length > 0 && (
               <>
                 <h2 className="text-lg font-semibold mb-2">
                   {t("relatedVideos")}
                 </h2>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  {Array.from(
-                    new Map(relatedAlbum.map((s) => [s.video_id, s])).values(),
-                  ).map((s) => {
-                    const internalHref = s.slugv2
-                      ? `/discography/${category}/${encodeURIComponent(s.slugv2)}`
-                      : s.title
-                        ? `/discography/${category}/${encodeURIComponent(slugify(s.title))}`
-                        : "#";
-                    return (
-                      <div
-                        key={s.video_id}
-                        className="flex items-center gap-3 rounded-md overflow-hidden bg-gray-50/20 dark:bg-gray-800 p-2"
-                      >
-                        <div className="w-28 h-16 overflow-hidden rounded">
-                          <YoutubeThumbnail
-                            videoId={s.video_id}
-                            alt={s.video_title}
-                            className="w-full h-full"
-                            imageClassName="object-cover"
-                          />
-                        </div>
-                        <div className="text-sm flex-1">
-                          <div className="font-medium">
-                            <Link href={internalHref}>{s.title}</Link>
-                          </div>
-                          <div className="text-xs text-gray-600 dark:text-gray-300">
-                            {s.artist} - {s.sing}
-                          </div>
-                          <div className="mt-2 space-x-2">
-                            <a
-                              href={`https://www.youtube.com/watch?v=${s.video_id}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-block bg-red-600 text-white py-1 px-3 rounded-md text-xs"
-                            >
-                              <FaYoutube className="inline mr-1 -mt-1" />{" "}
-                              {t("buttons.watchOnYouTube")}
-                            </a>
-                            <Link
-                              href={`/watch?q=video_id:${s.video_id}&v=${s.video_id}${Number(s.start) > 0 ? `&t=${s.start}` : ""}`}
-                              className="inline-block ml-1 bg-primary-600 text-white py-1 px-3 rounded-md text-xs"
-                            >
-                              <FaPlay className="inline mr-1 -mt-1" />{" "}
-                              {t("buttons.play")}
-                            </Link>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
+                  {relatedAlbumGroups.map((group) => (
+                    <RelatedVideoCard
+                      key={group.key}
+                      group={group}
+                      category={category}
+                      locale={locale}
+                    />
+                  ))}
                 </div>
               </>
             )}
 
-            {relatedSameTitle && relatedSameTitle.length > 0 && (
+            {relatedSameTitleGroups.length > 0 && (
               <>
                 <h2 className="text-lg font-semibold mb-2 mt-4">
-                  {t("relatedStreamsTitle", { count: relatedSameTitle.length })}
+                  {t("relatedStreamsTitle", {
+                    count: relatedSameTitleGroups.length,
+                  })}
                 </h2>
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-                  {Array.from(
-                    new Map(
-                      relatedSameTitle.map((s) => [s.video_id, s]),
-                    ).values(),
-                  ).map((s) => {
-                    const internalHref = s.slug
-                      ? `/discography/${encodeURIComponent(s.slug)}`
-                      : s.title
-                        ? `/discography/${encodeURIComponent(slugify(s.title))}`
-                        : "#";
-                    return (
-                      <div
-                        key={s.video_id}
-                        className="flex items-center gap-2 rounded-md overflow-hidden bg-gray-50/20 dark:bg-gray-800 p-2"
-                      >
-                        <div className="w-28 h-16 overflow-hidden rounded">
-                          <YoutubeThumbnail
-                            videoId={s.video_id}
-                            alt={s.video_title}
-                            className="w-full h-full"
-                            imageClassName="object-cover"
-                          />
-                        </div>
-                        <div className="text-sm flex-1">
-                          <div className="font-medium">{s.video_title}</div>
-                          <div className="text-xs text-gray-600 dark:text-gray-300">
-                            {t("labels.publishedDate")}{" "}
-                            {formatDate(s.broadcast_at, locale)}
-                          </div>
-                          <div className="mt-2 space-x-2">
-                            <a
-                              href={`https://www.youtube.com/watch?v=${s.video_id}${Number(s.start) > 0 ? `&t=${s.start}s` : ""}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-block bg-red-600 text-white py-1 px-3 rounded-md text-xs"
-                            >
-                              <FaYoutube className="inline mr-1 -mt-1" />{" "}
-                              {t("buttons.watchOnYouTube")}
-                            </a>
-                            <Link
-                              href={`/watch?q=video_id:${s.video_id}&v=${s.video_id}${Number(s.start) > 0 ? `&t=${s.start}` : ""}`}
-                              className="inline-block ml-1 bg-primary-600 text-white py-1 px-3 rounded-md text-xs"
-                            >
-                              <FaPlay className="inline mr-1 -mt-1" />{" "}
-                              {t("buttons.play")}
-                            </Link>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
+                  {relatedSameTitleGroups.map((group) => (
+                    <RelatedVideoCard
+                      key={group.key}
+                      group={group}
+                      category={category}
+                      locale={locale}
+                      showPublishedDate
+                    />
+                  ))}
                 </div>
               </>
             )}

--- a/src/app/discography/[category]/[slug]/ClientPage.tsx
+++ b/src/app/discography/[category]/[slug]/ClientPage.tsx
@@ -152,11 +152,13 @@ export default function ClientPage({
   );
   const currentVariantGroup = useMemo(() => {
     if (!preferredMatchedSong) return null;
-    const groupKey = getReleaseVariantGroupKey(preferredMatchedSong);
+    const instanceKey = getSongInstanceKey(preferredMatchedSong);
     return (
-      groupReleaseVariants(
-        songs.filter((song) => getReleaseVariantGroupKey(song) === groupKey),
-      )[0] ?? null
+      groupReleaseVariants(songs).find((group) =>
+        group.variants.some(
+          (variant) => getSongInstanceKey(variant) === instanceKey,
+        ),
+      ) ?? null
     );
   }, [preferredMatchedSong, songs]);
   const song =
@@ -241,6 +243,10 @@ export default function ClientPage({
 
   const isCover = isCoverSong(song);
   const singerSeparator = locale.startsWith("ja") ? "、" : ", ";
+  const breadcrumbAlbumTitle =
+    currentVariantGroup && currentVariantGroup.variants.length > 1
+      ? currentVariantGroup.representative.title?.trim()
+      : song.album?.trim();
 
   // 現在のページのURL
   const currentUrl = typeof window !== "undefined" ? window.location.href : "";
@@ -258,15 +264,16 @@ export default function ClientPage({
                   : t("unitLabel"),
             href: `/discography/${encodeURIComponent(category)}`,
           },
-          ...(song.album
+          ...(breadcrumbAlbumTitle
             ? [
                 {
                   label: (
                     <>
-                      <LuFolder className="inline mr-1" /> {song.album}
+                      <LuFolder className="inline mr-1" />{" "}
+                      {breadcrumbAlbumTitle}
                     </>
                   ),
-                  href: `/discography/album/${encodeURIComponent(slugify(song.album))}`,
+                  href: `/discography/album/${encodeURIComponent(slugify(breadcrumbAlbumTitle))}`,
                 },
               ]
             : []),

--- a/src/app/discography/[category]/[slug]/page.tsx
+++ b/src/app/discography/[category]/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/app/config/filters";
 import { fetchSongsFromApiCached } from "@/app/lib/server/fetchSongs";
 import ClientPage from "./ClientPage";
+import { chooseReleaseRepresentative } from "../../utils/releaseVariants";
 
 export async function generateStaticParams() {
   let songs: Song[] = [];
@@ -76,13 +77,7 @@ export async function generateMetadata({
       (s.title && slugify(s.title) === slug) ||
       (s.album && slugify(s.album) === slug),
   );
-  const matchedForMeta =
-    metadataCandidates.length > 1
-      ? (metadataCandidates.find((s) =>
-          // タグ配列内の要素に "MV" を含むものを優先（部分一致）
-          s.tags?.some((t) => t.includes("MV")),
-        ) ?? metadataCandidates[0])
-      : metadataCandidates[0];
+  const matchedForMeta = chooseReleaseRepresentative(metadataCandidates);
   const canonical = new URL(
     `/discography/${encodeURIComponent(resolved.category)}/${encodeURIComponent(slug)}`,
     baseUrl,

--- a/src/app/discography/album/[slug]/page.tsx
+++ b/src/app/discography/album/[slug]/page.tsx
@@ -13,6 +13,7 @@ type AlbumEntry = {
   slug: string;
   songs: Song[];
   representativeSong: Song;
+  releaseGroupKey?: string;
 };
 
 function buildAlbumEntries(songs: Song[]): AlbumEntry[] {
@@ -47,6 +48,32 @@ function buildAlbumEntries(songs: Song[]): AlbumEntry[] {
       slug: resolvedSlug,
       songs: releaseGroups.map((group) => group.representative),
       representativeSong,
+    });
+  }
+
+  const standaloneReleaseGroups = groupReleaseVariants(songs).filter(
+    (group) =>
+      group.variants.length > 1 &&
+      group.variants.some((song) => !song.album?.trim()),
+  );
+
+  for (const group of standaloneReleaseGroups.sort((a, b) =>
+    a.representative.title.localeCompare(b.representative.title, "ja"),
+  )) {
+    const title = group.representative.title?.trim();
+    if (!title) continue;
+
+    const baseSlug = slugify(title) || "album";
+    const count = slugCounts.get(baseSlug) ?? 0;
+    slugCounts.set(baseSlug, count + 1);
+    const resolvedSlug = count === 0 ? baseSlug : `${baseSlug}-${count + 1}`;
+
+    entries.push({
+      album: title,
+      slug: resolvedSlug,
+      songs: [group.representative],
+      representativeSong: group.representative,
+      releaseGroupKey: group.key,
     });
   }
 
@@ -182,6 +209,7 @@ export default async function DiscographyAlbumPage({
     <AlbumClient
       albumName={matched.album}
       coverVideoId={matched.representativeSong.video_id}
+      releaseGroupKey={matched.releaseGroupKey}
     />
   );
 }

--- a/src/app/discography/album/[slug]/page.tsx
+++ b/src/app/discography/album/[slug]/page.tsx
@@ -6,6 +6,7 @@ import slugify from "../../../lib/slugify";
 import { siteConfig, baseUrl } from "@/app/config/siteConfig";
 import { fetchSongsFromApiCached } from "@/app/lib/server/fetchSongs";
 import AlbumClient from "../../[category]/AlbumClient";
+import { groupReleaseVariants } from "../../utils/releaseVariants";
 
 type AlbumEntry = {
   album: string;
@@ -37,12 +38,15 @@ function buildAlbumEntries(songs: Song[]): AlbumEntry[] {
     const resolvedSlug = count === 0 ? baseSlug : `${baseSlug}-${count + 1}`;
     const albumSongs = grouped.get(album) ?? [];
     if (albumSongs.length === 0) continue;
+    const releaseGroups = groupReleaseVariants(albumSongs);
+    const representativeSong =
+      releaseGroups[0]?.representative ?? albumSongs[0];
 
     entries.push({
       album,
       slug: resolvedSlug,
-      songs: albumSongs,
-      representativeSong: albumSongs[0],
+      songs: releaseGroups.map((group) => group.representative),
+      representativeSong,
     });
   }
 

--- a/src/app/discography/client.tsx
+++ b/src/app/discography/client.tsx
@@ -69,6 +69,7 @@ export default function DiscographyClient({
     originalSongCountsByReleaseDate,
     unitSongCountsByReleaseDate,
     coverSongCountsByReleaseDate,
+    tabCounts,
   } = useDiscographyData(groupByAlbum, onlyOriginalMV);
 
   useEffect(() => {
@@ -221,7 +222,7 @@ export default function DiscographyClient({
               ref={tabRefCallbacks["0"]}
               className={discographyTabClass}
             >
-              {t("tabs.all", { count: allSongCountsByReleaseDate.length })}
+              {t("tabs.all", { count: tabCounts.all })}
             </Tabs.Tab>
             <Tabs.Tab
               value="1"
@@ -229,7 +230,7 @@ export default function DiscographyClient({
               className={discographyTabClass}
             >
               {t("tabs.originals", {
-                count: originalSongCountsByReleaseDate.length,
+                count: tabCounts.originals,
               })}
             </Tabs.Tab>
             <Tabs.Tab
@@ -237,14 +238,14 @@ export default function DiscographyClient({
               ref={tabRefCallbacks["2"]}
               className={discographyTabClass}
             >
-              {t("tabs.unit", { count: unitSongCountsByReleaseDate.length })}
+              {t("tabs.unit", { count: tabCounts.unit })}
             </Tabs.Tab>
             <Tabs.Tab
               value="3"
               ref={tabRefCallbacks["3"]}
               className={discographyTabClass}
             >
-              {t("tabs.covers", { count: coverSongCountsByReleaseDate.length })}
+              {t("tabs.covers", { count: tabCounts.covers })}
             </Tabs.Tab>
             <FloatingIndicator
               target={tabRefs[String(indicatorTab)]}

--- a/src/app/discography/components/ReleaseVariantSwitcher.tsx
+++ b/src/app/discography/components/ReleaseVariantSwitcher.tsx
@@ -18,6 +18,11 @@ type ReleaseVariantSwitcherProps = {
   testId?: string;
 };
 
+const circledNumbers = ["①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩"];
+
+const toVariantIndexLabel = (index: number) =>
+  circledNumbers[index] ?? `(${index + 1})`;
+
 export default function ReleaseVariantSwitcher({
   variants,
   value,
@@ -32,16 +37,32 @@ export default function ReleaseVariantSwitcher({
     return null;
   }
 
+  const kindCounts = selectableVariants.reduce((counts, variant) => {
+    const kind = getReleaseVariantKind(variant);
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+    return counts;
+  }, new Map<ReturnType<typeof getReleaseVariantKind>, number>());
+  const kindSeen = new Map<ReturnType<typeof getReleaseVariantKind>, number>();
+
   const data = selectableVariants.map((variant) => {
     const kind = getReleaseVariantKind(variant);
+    const baseLabel =
+      kind === "mv"
+        ? t("mv")
+        : kind === "animated"
+          ? t("animated")
+          : kind === "art-track"
+            ? t("artTrack")
+            : t("other");
+    const kindIndex = kindSeen.get(kind) ?? 0;
+    kindSeen.set(kind, kindIndex + 1);
+
     return {
       value: getSongInstanceKey(variant),
       label:
-        kind === "mv"
-          ? t("mv")
-          : kind === "art-track"
-            ? t("artTrack")
-            : t("other"),
+        (kindCounts.get(kind) ?? 0) > 1
+          ? `${baseLabel}${toVariantIndexLabel(kindIndex)}`
+          : baseLabel,
     };
   });
   const resolvedValue = data.some((item) => item.value === value)

--- a/src/app/discography/components/ReleaseVariantSwitcher.tsx
+++ b/src/app/discography/components/ReleaseVariantSwitcher.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { SegmentedControl } from "@mantine/core";
+import { useTranslations } from "next-intl";
+import type { Song } from "../../types/song";
+import {
+  getReleaseVariantKind,
+  getSelectableReleaseVariants,
+  getSongInstanceKey,
+  hasMultipleReleaseVariants,
+} from "../utils/releaseVariants";
+
+type ReleaseVariantSwitcherProps = {
+  variants: Song[];
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+  testId?: string;
+};
+
+export default function ReleaseVariantSwitcher({
+  variants,
+  value,
+  onChange,
+  className,
+  testId,
+}: ReleaseVariantSwitcherProps) {
+  const t = useTranslations("Discography.releaseVariants");
+  const selectableVariants = getSelectableReleaseVariants(variants);
+
+  if (!hasMultipleReleaseVariants(selectableVariants)) {
+    return null;
+  }
+
+  const data = selectableVariants.map((variant) => {
+    const kind = getReleaseVariantKind(variant);
+    return {
+      value: getSongInstanceKey(variant),
+      label:
+        kind === "mv"
+          ? t("mv")
+          : kind === "art-track"
+            ? t("artTrack")
+            : t("other"),
+    };
+  });
+  const resolvedValue = data.some((item) => item.value === value)
+    ? value
+    : data[0].value;
+
+  return (
+    <SegmentedControl
+      aria-label={t("switcherLabel")}
+      data-testid={testId}
+      className={className}
+      radius="md"
+      size="xs"
+      value={resolvedValue}
+      onChange={onChange}
+      data={data}
+      classNames={{
+        root: "border border-pink-200/70 bg-white/70 p-0.5 dark:border-white/10 dark:bg-gray-800/80",
+        indicator: "bg-primary-600 dark:bg-primary-500",
+        label:
+          "px-2 py-1 text-xs font-semibold text-gray-700 data-[active=true]:text-white dark:text-gray-200 dark:data-[active=true]:text-white",
+      }}
+    />
+  );
+}

--- a/src/app/discography/hooks/useDiscographyData.ts
+++ b/src/app/discography/hooks/useDiscographyData.ts
@@ -3,14 +3,26 @@ import { Song } from "../../types/song";
 import { createStatistics } from "../createStatistics";
 import useSongs from "../../hook/useSongs";
 import {
-  filterOriginalSongs,
   isCollaborationSong,
   isCoverSong,
   isFesOverallSong,
-  isOriginalSong,
   isPossibleOriginalSong,
 } from "@/app/config/filters";
 import { normalizeSongTitle } from "../utils/normalizeSongTitle";
+import { groupReleaseVariants } from "../utils/releaseVariants";
+import type { StatisticsItem } from "../createStatistics";
+
+const applyReleaseVariantGrouping = (item: StatisticsItem): StatisticsItem => {
+  const groups = groupReleaseVariants(item.videos ?? []);
+  if (groups.length === 0) return item;
+
+  return {
+    ...item,
+    count: groups.length,
+    firstVideo: groups[0].representative,
+    lastVideo: groups[groups.length - 1].representative,
+  };
+};
 
 /**
  * Discographyページのデータフェッチと統計計算を管理するカスタムフック
@@ -37,7 +49,7 @@ export function useDiscographyData(
       (s) =>
         groupByAlbum ? s.album || getSongKeyTitle(s) : getSongKeyTitle(s),
       groupByAlbum,
-    );
+    ).map(applyReleaseVariantGrouping);
   }, [songs, groupByAlbum, onlyOriginalMV]);
 
   // ユニット/ゲスト楽曲の統計
@@ -50,7 +62,7 @@ export function useDiscographyData(
       (s) =>
         groupByAlbum ? s.album || getSongKeyTitle(s) : getSongKeyTitle(s),
       groupByAlbum,
-    );
+    ).map(applyReleaseVariantGrouping);
   }, [songs, groupByAlbum]);
 
   // カバー楽曲の統計
@@ -75,7 +87,7 @@ export function useDiscographyData(
         return singers ? `${normalizedTitle}__${singers}` : normalizedTitle;
       },
       groupByAlbum,
-    );
+    ).map(applyReleaseVariantGrouping);
   }, [songs, groupByAlbum]);
 
   // 全楽曲の統計
@@ -93,7 +105,7 @@ export function useDiscographyData(
       (s) =>
         groupByAlbum ? s.album || getSongKeyTitle(s) : getSongKeyTitle(s),
       groupByAlbum,
-    );
+    ).map(applyReleaseVariantGrouping);
   }, [songs, groupByAlbum]);
 
   return {

--- a/src/app/discography/hooks/useDiscographyData.ts
+++ b/src/app/discography/hooks/useDiscographyData.ts
@@ -66,12 +66,16 @@ export function useDiscographyData(
     s.album ||
     getSongKeyTitle(s);
   const tabCounts = useMemo(() => {
-    const countStatisticsItems = (items: Song[], keyFn: (song: Song) => string) =>
+    const countStatisticsItems = (
+      items: Song[],
+      keyFn: (song: Song) => string,
+    ) =>
       createStatistics(items, keyFn, false).map(applyReleaseVariantGrouping)
         .length;
 
     const originals = songs.filter((s) => {
-      const isOriginal = s.tags.includes("オリ曲") || s.tags.includes("オリ曲MV");
+      const isOriginal =
+        s.tags.includes("オリ曲") || s.tags.includes("オリ曲MV");
       return isOriginal && isPossibleOriginalSong(s);
     });
     const units = songs.filter(

--- a/src/app/discography/hooks/useDiscographyData.ts
+++ b/src/app/discography/hooks/useDiscographyData.ts
@@ -65,6 +65,45 @@ export function useDiscographyData(
     releaseVariantAlbumKeyByInstance.get(getSongInstanceKey(s)) ||
     s.album ||
     getSongKeyTitle(s);
+  const tabCounts = useMemo(() => {
+    const countStatisticsItems = (items: Song[], keyFn: (song: Song) => string) =>
+      createStatistics(items, keyFn, false).map(applyReleaseVariantGrouping)
+        .length;
+
+    const originals = songs.filter((s) => {
+      const isOriginal = s.tags.includes("オリ曲") || s.tags.includes("オリ曲MV");
+      return isOriginal && isPossibleOriginalSong(s);
+    });
+    const units = songs.filter(
+      (s) => isCollaborationSong(s) || isFesOverallSong(s),
+    );
+    const covers = songs.filter((s) => isCoverSong(s));
+    const allFiltered = songs.filter(
+      (s) =>
+        isPossibleOriginalSong(s) ||
+        isCollaborationSong(s) ||
+        isFesOverallSong(s) ||
+        isCoverSong(s),
+    );
+    const normalizeSingers = (s: Song) =>
+      ((s.sing || "") as string)
+        .split("、")
+        .map((x) => x.trim())
+        .filter(Boolean)
+        .sort()
+        .join("、");
+
+    return {
+      all: countStatisticsItems(allFiltered, getSongKeyTitle),
+      originals: countStatisticsItems(originals, getSongKeyTitle),
+      unit: countStatisticsItems(units, getSongKeyTitle),
+      covers: countStatisticsItems(covers, (song) => {
+        const singers = normalizeSingers(song);
+        const normalizedTitle = getSongKeyTitle(song);
+        return singers ? `${normalizedTitle}__${singers}` : normalizedTitle;
+      }),
+    };
+  }, [songs]);
 
   // オリジナル楽曲の統計
   const originalSongCountsByReleaseDate = useMemo(() => {
@@ -147,5 +186,6 @@ export function useDiscographyData(
     unitSongCountsByReleaseDate,
     coverSongCountsByReleaseDate,
     allSongCountsByReleaseDate,
+    tabCounts,
   };
 }

--- a/src/app/discography/hooks/useDiscographyData.ts
+++ b/src/app/discography/hooks/useDiscographyData.ts
@@ -9,16 +9,24 @@ import {
   isPossibleOriginalSong,
 } from "@/app/config/filters";
 import { normalizeSongTitle } from "../utils/normalizeSongTitle";
-import { groupReleaseVariants } from "../utils/releaseVariants";
+import {
+  getSongInstanceKey,
+  groupReleaseVariants,
+} from "../utils/releaseVariants";
 import type { StatisticsItem } from "../createStatistics";
 
 const applyReleaseVariantGrouping = (item: StatisticsItem): StatisticsItem => {
   const groups = groupReleaseVariants(item.videos ?? []);
   if (groups.length === 0) return item;
+  const isStandaloneReleaseGroup =
+    groups.length === 1 &&
+    groups[0].variants.length > 1 &&
+    groups[0].variants.some((song) => !song.album?.trim());
 
   return {
     ...item,
     count: groups.length,
+    isAlbum: isStandaloneReleaseGroup ? false : item.isAlbum,
     firstVideo: groups[0].representative,
     lastVideo: groups[groups.length - 1].representative,
   };
@@ -35,6 +43,28 @@ export function useDiscographyData(
   const loading = isLoading;
   const songs = allSongs;
   const getSongKeyTitle = (s: Song) => normalizeSongTitle(s.title, s.artist);
+  const releaseVariantAlbumKeyByInstance = useMemo(() => {
+    const map = new Map<string, string>();
+    const standaloneReleaseGroups = groupReleaseVariants(songs).filter(
+      (group) =>
+        group.variants.length > 1 &&
+        group.variants.some((song) => !song.album?.trim()),
+    );
+
+    for (const group of standaloneReleaseGroups) {
+      const title = group.representative.title?.trim();
+      if (!title) continue;
+      for (const variant of group.variants) {
+        map.set(getSongInstanceKey(variant), title);
+      }
+    }
+
+    return map;
+  }, [songs]);
+  const getAlbumGroupingKey = (s: Song) =>
+    releaseVariantAlbumKeyByInstance.get(getSongInstanceKey(s)) ||
+    s.album ||
+    getSongKeyTitle(s);
 
   // オリジナル楽曲の統計
   const originalSongCountsByReleaseDate = useMemo(() => {
@@ -46,11 +76,10 @@ export function useDiscographyData(
     });
     return createStatistics(
       originals,
-      (s) =>
-        groupByAlbum ? s.album || getSongKeyTitle(s) : getSongKeyTitle(s),
+      (s) => (groupByAlbum ? getAlbumGroupingKey(s) : getSongKeyTitle(s)),
       groupByAlbum,
     ).map(applyReleaseVariantGrouping);
-  }, [songs, groupByAlbum, onlyOriginalMV]);
+  }, [songs, groupByAlbum, onlyOriginalMV, releaseVariantAlbumKeyByInstance]);
 
   // ユニット/ゲスト楽曲の統計
   const unitSongCountsByReleaseDate = useMemo(() => {
@@ -59,11 +88,10 @@ export function useDiscographyData(
     );
     return createStatistics(
       units,
-      (s) =>
-        groupByAlbum ? s.album || getSongKeyTitle(s) : getSongKeyTitle(s),
+      (s) => (groupByAlbum ? getAlbumGroupingKey(s) : getSongKeyTitle(s)),
       groupByAlbum,
     ).map(applyReleaseVariantGrouping);
-  }, [songs, groupByAlbum]);
+  }, [songs, groupByAlbum, releaseVariantAlbumKeyByInstance]);
 
   // カバー楽曲の統計
   const coverSongCountsByReleaseDate = useMemo(() => {
@@ -82,13 +110,18 @@ export function useDiscographyData(
         const singers = normalizeSingers(s);
         const normalizedTitle = getSongKeyTitle(s);
         if (groupByAlbum) {
-          return s.album || `${normalizedTitle}__${singers}` || normalizedTitle;
+          return (
+            releaseVariantAlbumKeyByInstance.get(getSongInstanceKey(s)) ||
+            s.album ||
+            `${normalizedTitle}__${singers}` ||
+            normalizedTitle
+          );
         }
         return singers ? `${normalizedTitle}__${singers}` : normalizedTitle;
       },
       groupByAlbum,
     ).map(applyReleaseVariantGrouping);
-  }, [songs, groupByAlbum]);
+  }, [songs, groupByAlbum, releaseVariantAlbumKeyByInstance]);
 
   // 全楽曲の統計
   const allSongCountsByReleaseDate = useMemo(() => {
@@ -102,11 +135,10 @@ export function useDiscographyData(
     return createStatistics(
       // ユニークにする
       allFiltered,
-      (s) =>
-        groupByAlbum ? s.album || getSongKeyTitle(s) : getSongKeyTitle(s),
+      (s) => (groupByAlbum ? getAlbumGroupingKey(s) : getSongKeyTitle(s)),
       groupByAlbum,
     ).map(applyReleaseVariantGrouping);
-  }, [songs, groupByAlbum]);
+  }, [songs, groupByAlbum, releaseVariantAlbumKeyByInstance]);
 
   return {
     loading,

--- a/src/app/discography/utils/__tests__/releaseVariants.test.ts
+++ b/src/app/discography/utils/__tests__/releaseVariants.test.ts
@@ -3,6 +3,7 @@ import type { Song } from "../../../types/song";
 import {
   chooseReleaseRepresentative,
   getReleaseVariantKind,
+  getSelectableReleaseVariants,
   groupReleaseVariants,
   hasMultipleReleaseVariants,
 } from "../releaseVariants";
@@ -119,6 +120,94 @@ describe("releaseVariants", () => {
 
     expect(groups).toHaveLength(2);
     expect(groups.every((group) => group.variants)).toBe(true);
+  });
+
+  it("アルバムがない同一曲・同一アーティストの複数MVを1グループにする", () => {
+    const groups = groupReleaseVariants([
+      baseSong({
+        title: "from A to Z",
+        artist: "AZKi",
+        album: "",
+        video_id: "main-mv",
+        tags: ["オリ曲MV"],
+        source_order: 2,
+      }),
+      baseSong({
+        title: "from A to Z",
+        artist: "AZKi",
+        album: "",
+        video_id: "early-mv",
+        tags: ["オリ曲MV"],
+        source_order: 1,
+      }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].variants.map((song) => song.video_id)).toEqual([
+      "early-mv",
+      "main-mv",
+    ]);
+    expect(groups[0].representative.video_id).toBe("early-mv");
+    expect(hasMultipleReleaseVariants(groups[0].variants)).toBe(true);
+  });
+
+  it("複数MVは切替対象として両方残す", () => {
+    const selectableVariants = getSelectableReleaseVariants([
+      baseSong({
+        video_id: "mv-2",
+        tags: ["オリ曲MV"],
+        source_order: 2,
+      }),
+      baseSong({
+        video_id: "mv-1",
+        tags: ["オリ曲MV"],
+        source_order: 1,
+      }),
+    ]);
+
+    expect(selectableVariants.map((song) => song.video_id)).toEqual([
+      "mv-1",
+      "mv-2",
+    ]);
+    expect(hasMultipleReleaseVariants(selectableVariants)).toBe(true);
+  });
+
+  it("アニAZはアルバムが違っても同一曲・同一アーティストの元MVと1グループにする", () => {
+    const groups = groupReleaseVariants([
+      baseSong({
+        title: "猫ならばいける",
+        artist: "AZKi",
+        album: "",
+        video_id: "animated-mv",
+        tags: ["オリ曲MV", "アニAZ"],
+        source_order: 1,
+      }),
+      baseSong({
+        title: "猫ならばいける",
+        artist: "AZKi",
+        album: "Re:Creating world",
+        video_id: "original-mv",
+        tags: ["オリ曲MV"],
+        source_order: 2,
+      }),
+      baseSong({
+        title: "猫ならばいける",
+        artist: "AZKi",
+        album: "",
+        video_id: "live-performance",
+        tags: ["歌枠"],
+        source_order: 3,
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].variants.map((song) => song.video_id)).toEqual([
+      "original-mv",
+      "animated-mv",
+    ]);
+    expect(groups[0].representative.video_id).toBe("original-mv");
+    expect(getReleaseVariantKind(groups[0].variants[1])).toBe("animated");
+    expect(groups[1].representative.video_id).toBe("live-performance");
   });
 
   it("片方だけのMVまたはアートトラックは単独グループとして扱う", () => {

--- a/src/app/discography/utils/__tests__/releaseVariants.test.ts
+++ b/src/app/discography/utils/__tests__/releaseVariants.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { Song } from "../../../types/song";
+import {
+  chooseReleaseRepresentative,
+  getReleaseVariantKind,
+  groupReleaseVariants,
+  hasMultipleReleaseVariants,
+} from "../releaseVariants";
+
+const baseSong = (overrides: Partial<Song>): Song =>
+  ({
+    title: "Going My Way",
+    artist: "AZKi & 星街すいせい",
+    album: "Going My Way",
+    lyricist: "",
+    composer: "",
+    arranger: "",
+    album_list_uri: "",
+    album_release_at: "2026-05-19T00:00:00.000Z",
+    album_is_compilation: false,
+    sing: "AZKi、星街すいせい",
+    sings: ["AZKi", "星街すいせい"],
+    video_title: "",
+    video_uri: "",
+    video_id: "base-video",
+    start: 0,
+    end: 0,
+    broadcast_at: "2026-05-19T00:00:00.000Z",
+    year: 2026,
+    tags: ["オリ曲"],
+    milestones: [],
+    hl: {
+      ja: {
+        title: "Going My Way",
+        artist: "AZKi & 星街すいせい",
+        artists: ["AZKi", "星街すいせい"],
+        album: "Going My Way",
+        sing: "AZKi、星街すいせい",
+        sings: ["AZKi", "星街すいせい"],
+      },
+    },
+    ...overrides,
+  }) as Song;
+
+describe("releaseVariants", () => {
+  it("同一アルバム・同一曲・同一アーティストのMVとアートトラックを1グループにする", () => {
+    const groups = groupReleaseVariants([
+      baseSong({
+        video_id: "art-track",
+        source_order: 1,
+        tags: ["オリ曲", "アートトラック"],
+      }),
+      baseSong({
+        video_id: "music-video",
+        source_order: 2,
+        tags: ["オリ曲MV"],
+      }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].variants.map((song) => song.video_id)).toEqual([
+      "music-video",
+      "art-track",
+    ]);
+    expect(groups[0].representative.video_id).toBe("music-video");
+    expect(hasMultipleReleaseVariants(groups[0].variants)).toBe(true);
+  });
+
+  it("代表曲はMVをアートトラックより優先する", () => {
+    const representative = chooseReleaseRepresentative([
+      baseSong({
+        video_id: "art-track",
+        tags: ["オリ曲", "アートトラック"],
+        source_order: 1,
+      }),
+      baseSong({
+        video_id: "music-video",
+        tags: ["オリ曲MV"],
+        source_order: 99,
+      }),
+    ]);
+
+    expect(representative.video_id).toBe("music-video");
+  });
+
+  it("同名でも別アーティストや別アルバムは混ぜない", () => {
+    const groups = groupReleaseVariants([
+      baseSong({ video_id: "mv-1", tags: ["オリ曲MV"] }),
+      baseSong({
+        video_id: "mv-2",
+        artist: "AZKi",
+        tags: ["オリ曲MV"],
+      }),
+      baseSong({
+        video_id: "mv-3",
+        album: "Another Album",
+        tags: ["オリ曲MV"],
+      }),
+    ]);
+
+    expect(groups).toHaveLength(3);
+  });
+
+  it("歌枠などの通常動画は同名でも動画単位のままにする", () => {
+    const groups = groupReleaseVariants([
+      baseSong({
+        video_id: "live-1",
+        album: "",
+        tags: ["歌枠"],
+        broadcast_at: "2026-05-20T00:00:00.000Z",
+      }),
+      baseSong({
+        video_id: "live-2",
+        album: "",
+        tags: ["歌枠"],
+        broadcast_at: "2026-05-21T00:00:00.000Z",
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.every((group) => group.variants)).toBe(true);
+  });
+
+  it("片方だけのMVまたはアートトラックは単独グループとして扱う", () => {
+    const groups = groupReleaseVariants([
+      baseSong({ video_id: "mv-only", tags: ["オリ曲MV"] }),
+      baseSong({
+        video_id: "art-only",
+        title: "Only Art",
+        tags: ["オリ曲", "アートトラック"],
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(getReleaseVariantKind(groups[0].representative)).toBe("mv");
+    expect(getReleaseVariantKind(groups[1].representative)).toBe("art-track");
+  });
+});

--- a/src/app/discography/utils/releaseVariants.ts
+++ b/src/app/discography/utils/releaseVariants.ts
@@ -1,0 +1,145 @@
+import type { Song } from "../../types/song";
+import { normalizeSongTitle } from "./normalizeSongTitle";
+
+export type ReleaseVariantKind = "mv" | "art-track" | "other";
+
+export type ReleaseVariantGroup = {
+  key: string;
+  representative: Song;
+  variants: Song[];
+};
+
+const normalizeKeyPart = (value?: string) =>
+  (value || "").normalize("NFKC").trim().toLowerCase();
+
+const getSourceOrder = (song: Song, fallback: number) =>
+  song.source_order ?? fallback;
+
+export const isMusicVideo = (song: Song) =>
+  (song.tags || []).some((tag) => tag.includes("MV"));
+
+export const isArtTrack = (song: Song) =>
+  (song.tags || []).includes("アートトラック");
+
+export const getReleaseVariantKind = (song: Song): ReleaseVariantKind => {
+  if (isMusicVideo(song)) return "mv";
+  if (isArtTrack(song)) return "art-track";
+  return "other";
+};
+
+export const getSongInstanceKey = (song: Song) =>
+  `${song.video_id || "video"}__${Number(song.start ?? 0)}__${song.slugv2 || ""}`;
+
+const isReleaseVariantCandidate = (song: Song) =>
+  Boolean(song.album?.trim()) && (isMusicVideo(song) || isArtTrack(song));
+
+export const getReleaseVariantGroupKey = (song: Song) => {
+  if (!isReleaseVariantCandidate(song)) {
+    return `single::${getSongInstanceKey(song)}`;
+  }
+
+  const title = normalizeKeyPart(normalizeSongTitle(song.title, song.artist));
+  const artist = normalizeKeyPart(song.artist);
+  const album = normalizeKeyPart(song.album);
+
+  if (!title || !artist || !album) {
+    return `single::${getSongInstanceKey(song)}`;
+  }
+
+  return `release::${album}::${title}::${artist}`;
+};
+
+const variantPriority = (song: Song) => {
+  const kind = getReleaseVariantKind(song);
+  if (kind === "mv") return 0;
+  if (kind === "art-track") return 1;
+  return 2;
+};
+
+export const sortReleaseVariants = (songs: Song[]) =>
+  [...songs].sort((left, right) => {
+    const priorityDiff = variantPriority(left) - variantPriority(right);
+    if (priorityDiff !== 0) return priorityDiff;
+
+    const orderDiff =
+      getSourceOrder(left, Number.MAX_SAFE_INTEGER) -
+      getSourceOrder(right, Number.MAX_SAFE_INTEGER);
+    if (orderDiff !== 0) return orderDiff;
+
+    return getSongInstanceKey(left).localeCompare(getSongInstanceKey(right));
+  });
+
+export const chooseReleaseRepresentative = (songs: Song[]) =>
+  sortReleaseVariants(songs)[0];
+
+export const groupReleaseVariants = (songs: Song[]): ReleaseVariantGroup[] => {
+  const groups = new Map<
+    string,
+    {
+      firstIndex: number;
+      variants: Song[];
+    }
+  >();
+
+  songs.forEach((song, index) => {
+    const key = getReleaseVariantGroupKey(song);
+    const current = groups.get(key);
+    if (current) {
+      current.variants.push(song);
+      return;
+    }
+
+    groups.set(key, {
+      firstIndex: index,
+      variants: [song],
+    });
+  });
+
+  return Array.from(groups.entries())
+    .map(([key, group]) => {
+      const variants = sortReleaseVariants(group.variants);
+      return {
+        key,
+        firstIndex: group.firstIndex,
+        representative: variants[0],
+        variants,
+      };
+    })
+    .sort((left, right) => left.firstIndex - right.firstIndex)
+    .map(({ firstIndex: _firstIndex, ...group }) => group);
+};
+
+export const hasMultipleReleaseVariants = (variants: Song[]) => {
+  const kinds = new Set(
+    variants.map((variant) => getReleaseVariantKind(variant)),
+  );
+  return (
+    variants.length > 1 &&
+    (kinds.has("mv") || kinds.has("art-track")) &&
+    kinds.size > 1
+  );
+};
+
+export const getSelectableReleaseVariants = (variants: Song[]) => {
+  const selectedByKind = new Map<ReleaseVariantKind, Song>();
+
+  for (const variant of sortReleaseVariants(variants)) {
+    const kind = getReleaseVariantKind(variant);
+    if (!selectedByKind.has(kind)) {
+      selectedByKind.set(kind, variant);
+    }
+  }
+
+  return Array.from(selectedByKind.values());
+};
+
+export const findReleaseVariantByInstanceKey = (
+  variants: Song[],
+  instanceKey: string | null,
+) => {
+  if (!instanceKey) return null;
+  return (
+    variants.find((variant) => getSongInstanceKey(variant) === instanceKey) ??
+    null
+  );
+};

--- a/src/app/discography/utils/releaseVariants.ts
+++ b/src/app/discography/utils/releaseVariants.ts
@@ -1,7 +1,7 @@
 import type { Song } from "../../types/song";
 import { normalizeSongTitle } from "./normalizeSongTitle";
 
-export type ReleaseVariantKind = "mv" | "art-track" | "other";
+export type ReleaseVariantKind = "mv" | "animated" | "art-track" | "other";
 
 export type ReleaseVariantGroup = {
   key: string;
@@ -18,10 +18,14 @@ const getSourceOrder = (song: Song, fallback: number) =>
 export const isMusicVideo = (song: Song) =>
   (song.tags || []).some((tag) => tag.includes("MV"));
 
+export const isAnimatedAz = (song: Song) =>
+  (song.tags || []).includes("アニAZ");
+
 export const isArtTrack = (song: Song) =>
   (song.tags || []).includes("アートトラック");
 
 export const getReleaseVariantKind = (song: Song): ReleaseVariantKind => {
+  if (isAnimatedAz(song)) return "animated";
   if (isMusicVideo(song)) return "mv";
   if (isArtTrack(song)) return "art-track";
   return "other";
@@ -31,18 +35,37 @@ export const getSongInstanceKey = (song: Song) =>
   `${song.video_id || "video"}__${Number(song.start ?? 0)}__${song.slugv2 || ""}`;
 
 const isReleaseVariantCandidate = (song: Song) =>
-  Boolean(song.album?.trim()) && (isMusicVideo(song) || isArtTrack(song));
+  isMusicVideo(song) || isArtTrack(song);
+
+const getTitleArtistKeyParts = (song: Song) => {
+  const title = normalizeKeyPart(normalizeSongTitle(song.title, song.artist));
+  const artist = normalizeKeyPart(song.artist);
+  return { title, artist };
+};
+
+const getCrossAlbumReleaseVariantGroupKey = (song: Song) => {
+  if (!isReleaseVariantCandidate(song)) {
+    return `single::${getSongInstanceKey(song)}`;
+  }
+
+  const { title, artist } = getTitleArtistKeyParts(song);
+
+  if (!title || !artist) {
+    return `single::${getSongInstanceKey(song)}`;
+  }
+
+  return `release::cross-album::${title}::${artist}`;
+};
 
 export const getReleaseVariantGroupKey = (song: Song) => {
   if (!isReleaseVariantCandidate(song)) {
     return `single::${getSongInstanceKey(song)}`;
   }
 
-  const title = normalizeKeyPart(normalizeSongTitle(song.title, song.artist));
-  const artist = normalizeKeyPart(song.artist);
-  const album = normalizeKeyPart(song.album);
+  const { title, artist } = getTitleArtistKeyParts(song);
+  const album = normalizeKeyPart(song.album) || "no-album";
 
-  if (!title || !artist || !album) {
+  if (!title || !artist) {
     return `single::${getSongInstanceKey(song)}`;
   }
 
@@ -52,8 +75,9 @@ export const getReleaseVariantGroupKey = (song: Song) => {
 const variantPriority = (song: Song) => {
   const kind = getReleaseVariantKind(song);
   if (kind === "mv") return 0;
-  if (kind === "art-track") return 1;
-  return 2;
+  if (kind === "animated") return 1;
+  if (kind === "art-track") return 2;
+  return 3;
 };
 
 export const sortReleaseVariants = (songs: Song[]) =>
@@ -73,6 +97,12 @@ export const chooseReleaseRepresentative = (songs: Song[]) =>
   sortReleaseVariants(songs)[0];
 
 export const groupReleaseVariants = (songs: Song[]): ReleaseVariantGroup[] => {
+  const animatedTitleArtistKeys = new Set(
+    songs.filter(isAnimatedAz).map((song) => {
+      const { title, artist } = getTitleArtistKeyParts(song);
+      return title && artist ? `${title}::${artist}` : "";
+    }),
+  );
   const groups = new Map<
     string,
     {
@@ -82,7 +112,15 @@ export const groupReleaseVariants = (songs: Song[]): ReleaseVariantGroup[] => {
   >();
 
   songs.forEach((song, index) => {
-    const key = getReleaseVariantGroupKey(song);
+    const { title, artist } = getTitleArtistKeyParts(song);
+    const titleArtistKey = title && artist ? `${title}::${artist}` : "";
+    const shouldCrossAlbumGroup =
+      isReleaseVariantCandidate(song) &&
+      titleArtistKey &&
+      animatedTitleArtistKeys.has(titleArtistKey);
+    const key = shouldCrossAlbumGroup
+      ? getCrossAlbumReleaseVariantGroupKey(song)
+      : getReleaseVariantGroupKey(song);
     const current = groups.get(key);
     if (current) {
       current.variants.push(song);
@@ -115,22 +153,12 @@ export const hasMultipleReleaseVariants = (variants: Song[]) => {
   );
   return (
     variants.length > 1 &&
-    (kinds.has("mv") || kinds.has("art-track")) &&
-    kinds.size > 1
+    (kinds.has("mv") || kinds.has("animated") || kinds.has("art-track"))
   );
 };
 
 export const getSelectableReleaseVariants = (variants: Song[]) => {
-  const selectedByKind = new Map<ReleaseVariantKind, Song>();
-
-  for (const variant of sortReleaseVariants(variants)) {
-    const kind = getReleaseVariantKind(variant);
-    if (!selectedByKind.has(kind)) {
-      selectedByKind.set(kind, variant);
-    }
-  }
-
-  return Array.from(selectedByKind.values());
+  return sortReleaseVariants(variants);
 };
 
 export const findReleaseVariantByInstanceKey = (
@@ -143,3 +171,7 @@ export const findReleaseVariantByInstanceKey = (
     null
   );
 };
+
+export const matchesReleaseVariantGroupKey = (song: Song, groupKey: string) =>
+  getReleaseVariantGroupKey(song) === groupKey ||
+  getCrossAlbumReleaseVariantGroupKey(song) === groupKey;

--- a/src/app/hook/__tests__/useYoutubeThumbnailFallback.test.tsx
+++ b/src/app/hook/__tests__/useYoutubeThumbnailFallback.test.tsx
@@ -11,7 +11,7 @@ describe("useYoutubeThumbnailFallback", () => {
     );
 
     expect(result.current.imageUrl).toBe(
-      `https://img.youtube.com/vi/${testVideoId}/maxresdefault.jpg`,
+      `https://i.ytimg.com/vi_webp/${testVideoId}/maxresdefault.webp`,
     );
   });
 
@@ -20,31 +20,31 @@ describe("useYoutubeThumbnailFallback", () => {
       useYoutubeThumbnailFallback(testVideoId),
     );
 
-    expect(result.current.imageUrl).toContain("maxresdefault.jpg");
+    expect(result.current.imageUrl).toContain("maxresdefault.webp");
 
     act(() => {
       result.current.handleError();
     });
 
-    expect(result.current.imageUrl).toContain("maxresdefault.jpg?retry=1");
+    expect(result.current.imageUrl).toContain("maxresdefault.webp?retry=1");
 
     act(() => {
       result.current.handleError();
     });
 
-    expect(result.current.imageUrl).toContain("sddefault.jpg");
+    expect(result.current.imageUrl).toContain("sddefault.webp");
 
     act(() => {
       result.current.handleError();
     });
 
-    expect(result.current.imageUrl).toContain("sddefault.jpg?retry=1");
+    expect(result.current.imageUrl).toContain("sddefault.webp?retry=1");
 
     act(() => {
       result.current.handleError();
     });
 
-    expect(result.current.imageUrl).toContain("hqdefault.jpg");
+    expect(result.current.imageUrl).toContain("hqdefault.webp");
   });
 
   it("全ての解像度を試した後は再試行を停止する", () => {
@@ -82,7 +82,7 @@ describe("useYoutubeThumbnailFallback", () => {
       result.current.handleError(); // default
     });
 
-    expect(result.current.imageUrl).toContain("default.jpg");
+    expect(result.current.imageUrl).toContain("default.webp");
 
     // 最終到達後は何度呼んでもURLが変わらず、追加ログもしない
     act(() => {
@@ -92,7 +92,7 @@ describe("useYoutubeThumbnailFallback", () => {
       result.current.handleError();
     });
 
-    expect(result.current.imageUrl).toContain("default.jpg");
+    expect(result.current.imageUrl).toContain("default.webp");
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
 
     consoleWarnSpy.mockRestore();
@@ -114,14 +114,14 @@ describe("useYoutubeThumbnailFallback", () => {
       result.current.handleError();
     });
 
-    expect(result.current.imageUrl).toContain("video1/sddefault.jpg");
+    expect(result.current.imageUrl).toContain("video1/sddefault.webp");
 
     // videoIdを変更
     rerender({ videoId: "video2" });
 
     // 最高解像度にリセットされる
     expect(result.current.imageUrl).toBe(
-      "https://img.youtube.com/vi/video2/maxresdefault.jpg",
+      "https://i.ytimg.com/vi_webp/video2/maxresdefault.webp",
     );
   });
 
@@ -149,7 +149,7 @@ describe("useYoutubeThumbnailFallback", () => {
     });
 
     expect(result.current.imageUrl).toBe(
-      `https://img.youtube.com/vi/${testVideoId}/maxresdefault.jpg?retry=1`,
+      `https://i.ytimg.com/vi_webp/${testVideoId}/maxresdefault.webp?retry=1`,
     );
   });
 });

--- a/src/app/hook/useYoutubeThumbnailFallback.tsx
+++ b/src/app/hook/useYoutubeThumbnailFallback.tsx
@@ -11,7 +11,7 @@ const RESOLUTIONS = [
 type Resolution = (typeof RESOLUTIONS)[number];
 
 const getImageUrl = (videoId: string, resolution: Resolution): string => {
-  return `https://img.youtube.com/vi/${videoId}/${resolution}.jpg`;
+  return `https://i.ytimg.com/vi_webp/${videoId}/${resolution}.webp`;
 };
 
 interface YoutubeThumbnailFallbackResult {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -659,6 +659,12 @@
       "groupByYear": "Group by year",
       "onlyOriginalMV": "Original MVs only"
     },
+    "releaseVariants": {
+      "mv": "MV",
+      "artTrack": "Art Track",
+      "other": "Video",
+      "switcherLabel": "Switch video version"
+    },
     "tabDescriptions": {
       "originals": "A list of original songs.",
       "unit": "A list of unit / guest songs.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -661,6 +661,7 @@
     },
     "releaseVariants": {
       "mv": "MV",
+      "animated": "AniAZ",
       "artTrack": "Art Track",
       "other": "Video",
       "switcherLabel": "Switch video version"

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -650,6 +650,12 @@
       "groupByYear": "年ごとに区切る",
       "onlyOriginalMV": "オリ曲MVのみ"
     },
+    "releaseVariants": {
+      "mv": "MV",
+      "artTrack": "アートトラック",
+      "other": "動画",
+      "switcherLabel": "動画バージョンを切り替え"
+    },
     "tabDescriptions": {
       "originals": "オリジナル楽曲の一覧です。",
       "unit": "ユニット・ゲスト楽曲の一覧です。",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -652,6 +652,7 @@
     },
     "releaseVariants": {
       "mv": "MV",
+      "animated": "アニAZ",
       "artTrack": "アートトラック",
       "other": "動画",
       "switcherLabel": "動画バージョンを切り替え"


### PR DESCRIPTION
## features

- Discography
  - MVとアートトラックを同一扱いをするように
  - オリジナルMVと「アニAZ」を同一扱いするように
  - タブに表示している楽曲数を一定に（アルバムでグルーピングしても変わらないように）
- 全体的
  - YouTubeのサムネイルfallback処理を改善