### PR TITLE
fix: 曲の読み込み中に次曲へスキップする不具合を修正

### DIFF
--- a/src/app/hook/__tests__/useMainPlayerControls.test.tsx
+++ b/src/app/hook/__tests__/useMainPlayerControls.test.tsx
@@ -985,6 +985,37 @@ describe("useMainPlayerControls", () => {
     expect(mockPlayer.seekTo).toHaveBeenLastCalledWith(10, true);
   });
 
+  it("0:00開始の曲が読み込み中にENDEDしても次の楽曲へ遷移しない", () => {
+    const { result } = renderHook(() =>
+      useMainPlayerControls({
+        songs: mockSongs,
+        allSongs: mockSongs,
+        globalPlayer: mockGlobalPlayer,
+      }),
+    );
+
+    const mockPlayer = createMockPlayer("vid1", "Song 1");
+    mockPlayer.getCurrentTime.mockReturnValue(0);
+    mockPlayer.getDuration.mockReturnValue(0);
+
+    act(() => {
+      result.current.changeCurrentSong(mockSongs[0]);
+    });
+
+    act(() => {
+      result.current.handlePlayerOnReady({ target: mockPlayer } as any);
+    });
+
+    act(() => {
+      result.current.handlePlayerStateChange({
+        target: mockPlayer,
+        data: 0,
+      } as any);
+    });
+
+    expect(result.current.currentSong).toEqual(mockSongs[0]);
+  });
+
   it("0:00から再生開始した場合の補正シークは1回だけ試みる", () => {
     const { result } = renderHook(() =>
       useMainPlayerControls({

--- a/src/app/hook/__tests__/usePlayerControls.test.tsx
+++ b/src/app/hook/__tests__/usePlayerControls.test.tsx
@@ -1111,7 +1111,7 @@ describe("usePlayerControls", () => {
         ...filteredSongs,
         { ...mockSongs[2], video_id: "qVid", start: 200 },
       ];
-      const player = createMockPlayer("qVid", 350);
+      const player = createMockPlayer("qVid", 400, 400);
 
       const { result } = renderHook(() =>
         usePlayerControls(filteredSongs, allSongs, mockGlobalPlayer),
@@ -1124,12 +1124,98 @@ describe("usePlayerControls", () => {
       act(() => {
         result.current.handleStateChange({
           target: player,
+          data: YouTube.PlayerState.PLAYING,
+        } as any);
+        vi.advanceTimersByTime(500);
+      });
+
+      act(() => {
+        result.current.handleStateChange({
+          target: player,
           data: YouTube.PlayerState.ENDED,
         } as any);
       });
 
       expect(result.current.currentSong?.start).toBe(300);
       expect(result.current.currentSong?.start).not.toBe(200);
+    });
+
+    it("曲選択直後の読み込み中ENDEDでは次曲へ遷移しない", () => {
+      const songs: Song[] = [
+        { ...mockSongs[0], video_id: "loadVid", start: 0 },
+        { ...mockSongs[1], video_id: "loadVid", start: 100 },
+      ];
+      const player = createMockPlayer("loadVid", 0, 0);
+
+      const { result } = renderHook(() =>
+        usePlayerControls(songs, songs, mockGlobalPlayer),
+      );
+
+      act(() => {
+        result.current.changeCurrentSong(songs[0]);
+      });
+
+      act(() => {
+        result.current.handleStateChange({
+          target: player,
+          data: YouTube.PlayerState.ENDED,
+        } as any);
+      });
+
+      expect(result.current.currentSong?.start).toBe(0);
+      expect(result.current.currentSong?.title).toBe(songs[0].title);
+    });
+
+    it("開始位置へシークする前の0秒再生では次曲へ遷移しない", () => {
+      const songs: Song[] = [
+        { ...mockSongs[0], video_id: "seekVid", start: 0 },
+        { ...mockSongs[1], video_id: "seekVid", start: 100 },
+      ];
+      const player = createMockPlayer("seekVid", 0, 200);
+
+      const { result } = renderHook(() =>
+        usePlayerControls(songs, songs, mockGlobalPlayer),
+      );
+
+      act(() => {
+        result.current.changeCurrentSong(songs[1]);
+      });
+
+      act(() => {
+        result.current.handleStateChange({
+          target: player,
+          data: YouTube.PlayerState.PLAYING,
+        } as any);
+        vi.advanceTimersByTime(3001);
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(result.current.currentSong?.start).toBe(100);
+    });
+
+    it("本再生開始前のENDEDは動画メタデータがあっても次曲へ遷移しない", () => {
+      const songs: Song[] = [
+        { ...mockSongs[0], video_id: "metaVid", start: 0 },
+        { ...mockSongs[1], video_id: "metaVid", start: 100 },
+      ];
+      const player = createMockPlayer("metaVid", 0, 180);
+
+      const { result } = renderHook(() =>
+        usePlayerControls(songs, songs, mockGlobalPlayer),
+      );
+
+      act(() => {
+        result.current.changeCurrentSong(songs[0]);
+      });
+
+      act(() => {
+        result.current.handleStateChange({
+          target: player,
+          data: YouTube.PlayerState.ENDED,
+        } as any);
+      });
+
+      expect(result.current.currentSong?.start).toBe(0);
     });
 
     it("自動遷移ではskipSeekが使われる", () => {

--- a/src/app/hook/useMainPlayerControls.tsx
+++ b/src/app/hook/useMainPlayerControls.tsx
@@ -477,6 +477,10 @@ export default function useMainPlayerControls({
         typeof event.target.getCurrentTime === "function"
           ? event.target.getCurrentTime()
           : NaN;
+      const duration =
+        typeof event.target.getDuration === "function"
+          ? Number(event.target.getDuration())
+          : NaN;
       const initialPlaybackTarget = initialPlaybackTargetRef.current;
       const isBeforeInitialPlaybackTarget =
         initialPlaybackTarget !== null &&
@@ -485,11 +489,22 @@ export default function useMainPlayerControls({
         typeof currentTime === "number" &&
         Number.isFinite(currentTime) &&
         currentTime < initialPlaybackTarget - 1;
+      const isUnloadedVideo = !Number.isFinite(duration) || duration <= 0;
+      const isEndedBeforeVideoEnd =
+        event.data === 0 &&
+        Number.isFinite(duration) &&
+        duration > 0 &&
+        typeof currentTime === "number" &&
+        Number.isFinite(currentTime) &&
+        currentTime < duration - 2;
       const shouldDeferPlaybackState =
-        isBeforeInitialPlaybackTarget && (event.data === 1 || event.data === 0);
+        (isBeforeInitialPlaybackTarget &&
+          (event.data === 1 || event.data === 0)) ||
+        (event.data === 0 && (isUnloadedVideo || isEndedBeforeVideoEnd));
 
-      // 開始位置へ到達する前の PLAYING / ENDED を通常の再生監視へ渡すと、
-      // 0:00 を別の曲として判定して次曲へ進んでしまうため、シーク完了まで保留する。
+      // 開始位置へ到達する前、または動画未ロード時の PLAYING / ENDED を
+      // 通常の再生監視へ渡すと、読み込み中の 0:00 を再生終了とみなして
+      // 次曲へ進んでしまうため、シーク完了・本再生開始まで保留する。
       if (!shouldDeferPlaybackState) {
         originalHandleStateChange(event);
       }

--- a/src/app/hook/usePlayerControls.tsx
+++ b/src/app/hook/usePlayerControls.tsx
@@ -96,6 +96,9 @@ const usePlayerControls = (
   // (see src/app/lib/history.ts)
   const lastManualChangeRef = useRef<number>(0);
   const isManualChangeInProgressRef = useRef<boolean>(false);
+  // 選択した曲が実際に再生開始するまで、読み込み中の ENDED / 0秒位置を
+  // 再生終了とみなして次曲へ進まないようにする。
+  const hasReachedCurrentSongPlaybackRef = useRef(false);
   const lastEndClampRef = useRef<number>(0);
 
   // === ライブコール関連 ===
@@ -379,6 +382,7 @@ const usePlayerControls = (
       resetSongPlayCountSession();
 
       if (!options?.skipSeek) {
+        hasReachedCurrentSongPlaybackRef.current = false;
         setGlobalCurrentTime(targetStartTime);
       }
 
@@ -653,7 +657,47 @@ const usePlayerControls = (
         }
       }
 
+      const getPlayerDurationSeconds = () => {
+        try {
+          return Number(player.getDuration?.() ?? 0);
+        } catch (_) {
+          return 0;
+        }
+      };
+
+      const getPlayerCurrentTimeSeconds = () => {
+        try {
+          return Number(player.getCurrentTime?.() ?? NaN);
+        } catch (_) {
+          return NaN;
+        }
+      };
+
+      const markPlaybackReachedIfReady = (
+        currentTime?: number,
+        duration?: number,
+      ) => {
+        const song = currentSongRef.current;
+        if (!song) return;
+
+        const playingVideoId = player.getVideoData?.()?.video_id;
+        if (playingVideoId && playingVideoId !== song.video_id) return;
+
+        const time = currentTime ?? getPlayerCurrentTimeSeconds();
+        const videoDuration = duration ?? getPlayerDurationSeconds();
+        const songStart = Number(song.start ?? 0);
+        if (!Number.isFinite(time) || time < songStart - 1) return;
+
+        const hasLoadedMetadata =
+          Number.isFinite(videoDuration) && videoDuration > 0;
+        const hasProgressedPastStart = time >= songStart + 1;
+        if (!hasLoadedMetadata && !hasProgressedPastStart) return;
+
+        hasReachedCurrentSongPlaybackRef.current = true;
+      };
+
       const handlePlayingState = () => {
+        markPlaybackReachedIfReady();
         if (intervalRef.current) return;
 
         // ループ内でtimedMessagesをチェック
@@ -765,6 +809,21 @@ const usePlayerControls = (
             }
           } catch (_) {}
 
+          markPlaybackReachedIfReady(
+            currentTime,
+            Number(player.getDuration?.() ?? 0),
+          );
+
+          // 選択した曲の開始位置へ到達する前は、読み込み中の 0:00 を別曲として
+          // 判定して次曲へ進まない。
+          const selectedSongStart = Number(currentSongRef.current?.start ?? 0);
+          if (
+            Number.isFinite(currentTime) &&
+            currentTime < selectedSongStart - 1
+          ) {
+            return;
+          }
+
           // 自動切替: 同一動画内で再生位置が次の曲に移った場合、曲名を自動で更新する
           const currentPlayingVideoId = currentSongRef.current?.video_id;
           const isSameVideoPlaying =
@@ -827,6 +886,52 @@ const usePlayerControls = (
       const handleEndedState = () => {
         clearMonitorInterval();
         resetSongPlayCountSession();
+        setTimedLiveCallText(null);
+
+        const song = currentSongRef.current;
+        const playingVideoId = fetchedVideoData?.video_id;
+        if (
+          playingVideoId &&
+          song?.video_id &&
+          playingVideoId !== song.video_id
+        ) {
+          return;
+        }
+
+        // 読み込み未完了やシーク前の ENDED は再生終了ではない。
+        if (!hasReachedCurrentSongPlaybackRef.current) {
+          return;
+        }
+
+        const endedCurrentTime = getPlayerCurrentTimeSeconds();
+        const endedDuration = getPlayerDurationSeconds();
+        const songStart = Number(song?.start ?? 0);
+        const songEnd = Number(song?.end ?? 0);
+        if (
+          Number.isFinite(endedCurrentTime) &&
+          endedCurrentTime < songStart - 1
+        ) {
+          return;
+        }
+
+        const isNearVideoEnd =
+          Number.isFinite(endedDuration) &&
+          endedDuration > 0 &&
+          Number.isFinite(endedCurrentTime) &&
+          endedCurrentTime >= endedDuration - 2;
+        const isNearSongEnd =
+          songEnd > songStart &&
+          Number.isFinite(endedCurrentTime) &&
+          endedCurrentTime >= songEnd - 2;
+        if (
+          Number.isFinite(endedDuration) &&
+          endedDuration > 0 &&
+          !isNearVideoEnd &&
+          !isNearSongEnd
+        ) {
+          return;
+        }
+
         const nextSongInVideo = getNextSongInVideo(currentSongRef.current);
         // ended 時はまず同一動画内の次曲を探し、なければ filtered songs の次、最後に全体の先頭を再生
         let autoNextSong: Song | null = null;
@@ -859,8 +964,6 @@ const usePlayerControls = (
             changeCurrentSongRef.current(first);
           }
         }
-        // 再生終了時にメッセージをリセット
-        setTimedLiveCallText(null);
       };
       switch (event.data) {
         case YouTube.PlayerState.UNSTARTED:


### PR DESCRIPTION
読み込み中の ENDED やシーク前の 0:00 を再生終了として扱わないようにする。

fix #491